### PR TITLE
Add the ability of use case sensitive to 'exclusion' 

### DIFF
--- a/javascript/rails.validations.js
+++ b/javascript/rails.validations.js
@@ -215,7 +215,7 @@ var clientSideValidations = {
         } else {
           if (options['in']) {
             for (var i = 0; i < options['in'].length; i++) {
-              if (options['in'][i] == element.val()) {
+              if (options['in'][i] == (options['case_sensitive'] ? element.val() : element.val().toLowerCase())) {
                 return options.message;
               }
             }


### PR DESCRIPTION
For example:

```
  validates_exclusion_of :username, :in => ["admin", "root", "administrator", "superuser"]
```

Since Rails dont mind if you added more options [Rails doesn't throw any errors/warnings], I found that is useful to add case_sensitive to the validation. As the example above, if we want to check `root` as `username` it gives us `is reserved`, but if you try `Root` or `rooT` it will be allowed!!

And since `client_side_validations` doesn't support `before_validate` I suggest to use `case_sensitive` in exclusion by adding `:case_sensitive => false` to the validation in the model, and all the behavior will be fine!
