### PR TITLE
Formtastic::FormBuilder is used instead of Formtastic::SemanticFormBuilder in Formtastic-Edge

### DIFF
--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -402,3 +402,6 @@ var clientSideValidations = {
     }
   }
 }
+
+clientSideValidations.formBuilders['Formtastic::FormBuilder'] = clientSideValidations.formBuilders['Formtastic::SemanticFormBuilder'] 
+


### PR DESCRIPTION
Formtastic::SemanticFormBuilder does not exist(?) in Formtastic-edge (github).
The settings report Formtastic::FormBuilder. 
