### PR TITLE
Fix for fields_for nil problem

### DIFF
--- a/lib/client_side_validations/action_view/form_helper.rb
+++ b/lib/client_side_validations/action_view/form_helper.rb
@@ -43,7 +43,7 @@ module ClientSideValidations::ActionView::Helpers
 
     def fields_for(record_or_name_or_array, *args, &block)
       output = super
-      @validators.merge!(args.last[:validators]) if @validators
+      @validators.merge!(args.last[:validators]) if @validators && args.last && args.last[:validators]
       output
     end
 


### PR DESCRIPTION
Fix nil dereference that occurs if you have a form_for block that calls fields_for without specifying a :validators key/value in the args hash.

I'm using Haml so here is the code that was giving me problems...

``` haml
- form_for @merchant, :url => { :action => :create }, :validate => true do |f|

  -# Render some merchant fields with the form helper.

  = fields_for @merchant.contract_signature do |signature_fields|
```

The fields_for call above throws an exception. The workaround I am using is to replace the fields_for call like so...

``` haml
  = fields_for @merchant.contract_signature, :validators => {} do |signature_fields|
```

Here is the framework trace for the NoMethodError I was getting because args.last was nil...

```
client_side_validations (3.1.0) lib/client_side_validations/action_view/form_helper.rb:46:in `fields_for'
haml (3.1.2) lib/haml/helpers/action_view_mods.rb:179:in `call'
haml (3.1.2) lib/haml/helpers/action_view_mods.rb:179:in `block (2 levels) in form_for_with_haml'
haml (3.1.2) lib/haml/helpers.rb:255:in `with_tabs'
haml (3.1.2) lib/haml/helpers/action_view_mods.rb:179:in `block in form_for_with_haml'
actionpack (3.0.7) lib/action_view/helpers/capture_helper.rb:40:in `block in capture'
actionpack (3.0.7) lib/action_view/helpers/capture_helper.rb:172:in `with_output_buffer'
haml (3.1.2) lib/haml/helpers/xss_mods.rb:109:in `with_output_buffer_with_haml_xss'
actionpack (3.0.7) lib/action_view/helpers/capture_helper.rb:40:in `capture'
haml (3.1.2) lib/haml/helpers/action_view_mods.rb:104:in `capture_with_haml'
actionpack (3.0.7) lib/action_view/helpers/form_helper.rb:545:in `fields_for'
client_side_validations (3.1.0) lib/client_side_validations/action_view/form_helper.rb:45:in `fields_for'
actionpack (3.0.7) lib/action_view/helpers/form_helper.rb:320:in `form_for'
haml (3.1.2) lib/haml/helpers/action_view_mods.rb:181:in `form_for_with_haml'
haml (3.1.2) lib/haml/helpers/xss_mods.rb:132:in `form_for_with_haml_xss'
client_side_validations (3.1.0) lib/client_side_validations/action_view/form_helper.rb:28:in `form_for'
actionpack (3.0.7) lib/action_view/template.rb:135:in `block in render'
activesupport (3.0.7) lib/active_support/notifications.rb:54:in `instrument'
actionpack (3.0.7) lib/action_view/template.rb:127:in `render'
actionpack (3.0.7) lib/action_view/render/rendering.rb:59:in `block in _render_template'
activesupport (3.0.7) lib/active_support/notifications.rb:52:in `block in instrument'
activesupport (3.0.7) lib/active_support/notifications/instrumenter.rb:21:in `instrument'
activesupport (3.0.7) lib/active_support/notifications.rb:52:in `instrument'
actionpack (3.0.7) lib/action_view/render/rendering.rb:56:in `_render_template'
actionpack (3.0.7) lib/action_view/render/rendering.rb:26:in `render'
haml (3.1.2) lib/haml/helpers/action_view_mods.rb:13:in `render_with_haml'
actionpack (3.0.7) lib/abstract_controller/rendering.rb:115:in `_render_template'
actionpack (3.0.7) lib/abstract_controller/rendering.rb:109:in `render_to_body'
actionpack (3.0.7) lib/action_controller/metal/renderers.rb:47:in `render_to_body'
actionpack (3.0.7) lib/action_controller/metal/compatibility.rb:55:in `render_to_body'
actionpack (3.0.7) lib/abstract_controller/rendering.rb:102:in `render_to_string'
actionpack (3.0.7) lib/abstract_controller/rendering.rb:93:in `render'
actionpack (3.0.7) lib/action_controller/metal/rendering.rb:17:in `render'
actionpack (3.0.7) lib/action_controller/metal/instrumentation.rb:40:in `block (2 levels) in render'
activesupport (3.0.7) lib/active_support/core_ext/benchmark.rb:5:in `block in ms'
/Users/brent/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/benchmark.rb:309:in `realtime'
activesupport (3.0.7) lib/active_support/core_ext/benchmark.rb:5:in `ms'
actionpack (3.0.7) lib/action_controller/metal/instrumentation.rb:40:in `block in render'
actionpack (3.0.7) lib/action_controller/metal/instrumentation.rb:78:in `cleanup_view_runtime'
activerecord (3.0.7) lib/active_record/railties/controller_runtime.rb:15:in `cleanup_view_runtime'
actionpack (3.0.7) lib/action_controller/metal/instrumentation.rb:39:in `render'
actionpack (3.0.7) lib/action_controller/metal/implicit_render.rb:14:in `default_render'
actionpack (3.0.7) lib/action_controller/metal/implicit_render.rb:6:in `send_action'
actionpack (3.0.7) lib/abstract_controller/base.rb:150:in `process_action'
actionpack (3.0.7) lib/action_controller/metal/rendering.rb:11:in `process_action'
actionpack (3.0.7) lib/abstract_controller/callbacks.rb:18:in `block in process_action'
activesupport (3.0.7) lib/active_support/callbacks.rb:451:in `_run__953621487842837398__process_action__847506436440861146__callbacks'
activesupport (3.0.7) lib/active_support/callbacks.rb:410:in `_run_process_action_callbacks'
activesupport (3.0.7) lib/active_support/callbacks.rb:94:in `run_callbacks'
actionpack (3.0.7) lib/abstract_controller/callbacks.rb:17:in `process_action'
actionpack (3.0.7) lib/action_controller/metal/instrumentation.rb:30:in `block in process_action'
activesupport (3.0.7) lib/active_support/notifications.rb:52:in `block in instrument'
activesupport (3.0.7) lib/active_support/notifications/instrumenter.rb:21:in `instrument'
activesupport (3.0.7) lib/active_support/notifications.rb:52:in `instrument'
actionpack (3.0.7) lib/action_controller/metal/instrumentation.rb:29:in `process_action'
actionpack (3.0.7) lib/action_controller/metal/rescue.rb:17:in `process_action'
actionpack (3.0.7) lib/abstract_controller/base.rb:119:in `process'
actionpack (3.0.7) lib/abstract_controller/rendering.rb:41:in `process'
actionpack (3.0.7) lib/action_controller/metal.rb:138:in `dispatch'
actionpack (3.0.7) lib/action_controller/metal/rack_delegation.rb:14:in `dispatch'
actionpack (3.0.7) lib/action_controller/metal.rb:178:in `block in action'
actionpack (3.0.7) lib/action_dispatch/routing/route_set.rb:62:in `call'
actionpack (3.0.7) lib/action_dispatch/routing/route_set.rb:62:in `dispatch'
actionpack (3.0.7) lib/action_dispatch/routing/route_set.rb:27:in `call'
rack-mount (0.6.14) lib/rack/mount/route_set.rb:148:in `block in call'
rack-mount (0.6.14) lib/rack/mount/code_generation.rb:93:in `block in recognize'
rack-mount (0.6.14) lib/rack/mount/code_generation.rb:187:in `optimized_each'
rack-mount (0.6.14) lib/rack/mount/code_generation.rb:92:in `recognize'
rack-mount (0.6.14) lib/rack/mount/route_set.rb:139:in `call'
actionpack (3.0.7) lib/action_dispatch/routing/route_set.rb:493:in `call'
oa-core (0.2.0) lib/omniauth/strategy.rb:54:in `call!'
oa-core (0.2.0) lib/omniauth/strategy.rb:22:in `call'
oa-core (0.2.0) lib/omniauth/strategy.rb:54:in `call!'
oa-core (0.2.0) lib/omniauth/strategy.rb:22:in `call'
barista (1.2.1) lib/barista/server.rb:33:in `call'
barista (1.2.1) lib/barista/filter.rb:16:in `_call'
barista (1.2.1) lib/barista/filter.rb:9:in `call'
sass (3.1.4) lib/sass/plugin/rack.rb:54:in `call'
client_side_validations (3.1.0) lib/client_side_validations/middleware.rb:18:in `call'
warden (1.0.4) lib/warden/manager.rb:35:in `block in call'
warden (1.0.4) lib/warden/manager.rb:34:in `catch'
warden (1.0.4) lib/warden/manager.rb:34:in `call'
actionpack (3.0.7) lib/action_dispatch/middleware/best_standards_support.rb:17:in `call'
actionpack (3.0.7) lib/action_dispatch/middleware/head.rb:14:in `call'
rack (1.2.3) lib/rack/methodoverride.rb:24:in `call'
actionpack (3.0.7) lib/action_dispatch/middleware/params_parser.rb:21:in `call'
actionpack (3.0.7) lib/action_dispatch/middleware/flash.rb:182:in `call'
actionpack (3.0.7) lib/action_dispatch/middleware/session/abstract_store.rb:149:in `call'
actionpack (3.0.7) lib/action_dispatch/middleware/cookies.rb:302:in `call'
activerecord (3.0.7) lib/active_record/query_cache.rb:32:in `block in call'
activerecord (3.0.7) lib/active_record/connection_adapters/abstract/query_cache.rb:28:in `cache'
activerecord (3.0.7) lib/active_record/query_cache.rb:12:in `cache'
activerecord (3.0.7) lib/active_record/query_cache.rb:31:in `call'
activerecord (3.0.7) lib/active_record/connection_adapters/abstract/connection_pool.rb:354:in `call'
actionpack (3.0.7) lib/action_dispatch/middleware/callbacks.rb:46:in `block in call'
activesupport (3.0.7) lib/active_support/callbacks.rb:416:in `_run_call_callbacks'
actionpack (3.0.7) lib/action_dispatch/middleware/callbacks.rb:44:in `call'
rack (1.2.3) lib/rack/sendfile.rb:107:in `call'
actionpack (3.0.7) lib/action_dispatch/middleware/remote_ip.rb:48:in `call'
actionpack (3.0.7) lib/action_dispatch/middleware/show_exceptions.rb:47:in `call'
railties (3.0.7) lib/rails/rack/logger.rb:13:in `call'
rack (1.2.3) lib/rack/runtime.rb:17:in `call'
activesupport (3.0.7) lib/active_support/cache/strategy/local_cache.rb:72:in `call'
rack (1.2.3) lib/rack/lock.rb:11:in `block in call'
<internal:prelude>:10:in `synchronize'
rack (1.2.3) lib/rack/lock.rb:11:in `call'
actionpack (3.0.7) lib/action_dispatch/middleware/static.rb:30:in `call'
railties (3.0.7) lib/rails/application.rb:168:in `call'
railties (3.0.7) lib/rails/application.rb:77:in `method_missing'
railties (3.0.7) lib/rails/rack/log_tailer.rb:14:in `call'
rack (1.2.3) lib/rack/content_length.rb:13:in `call'
rack (1.2.3) lib/rack/handler/webrick.rb:52:in `service'
/Users/brent/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/webrick/httpserver.rb:111:in `service'
/Users/brent/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/webrick/httpserver.rb:70:in `run'
/Users/brent/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/webrick/server.rb:183:in `block in start_thread'
```
