### PR TITLE
Formtastic uses SemanticFormBuilder and not FormBuilder

### DIFF
--- a/lib/client_side_validations/formtastic.rb
+++ b/lib/client_side_validations/formtastic.rb
@@ -17,5 +17,5 @@ module ClientSideValidations
   end
 end
 
-Formtastic::FormBuilder.send(:include, ClientSideValidations::Formtastic::FormBuilder)
+Formtastic::SemanticFormBuilder.send(:include, ClientSideValidations::Formtastic::FormBuilder)
 


### PR DESCRIPTION
Simple change, enables client_side_validations:install task
