### PR TITLE
Validation: Only validate visible fields on form submission

### DIFF
--- a/test/javascript/public/test/form_builders/validateForm.js
+++ b/test/javascript/public/test/form_builders/validateForm.js
@@ -64,3 +64,13 @@ asyncTest('Validate form with an input changed to false', 1, function() {
   }, 30);
 });
 
+asyncTest('Validate form validates only visible elements', 1, function() {
+  var form = $('form#new_user'), input = form.find('input#user_name');
+  input.hide();
+
+  form.trigger('submit');
+  setTimeout(function() {
+    start();
+    ok($('iframe').contents().find('p:contains("Form submitted")')[0]);
+  }, 30);
+});

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -79,7 +79,7 @@
   var validateForm = function (form, validators) {
     var valid = true;
 
-    form.trigger('form:validate:before').find('[data-validate]:input').each(function() {
+    form.trigger('form:validate:before').find('[data-validate]:input:visible').each(function() {
       if (!$(this).isValid(validators)) { valid = false; }
     });
 


### PR DESCRIPTION
This pull request changes form validation to only validate visible input fields on form submission.

Useful when eg. input elements shown/hidden based on conditionals and posted to some other service than your Rails backend. In my case I'm validating a credit card form and posting the data for directly at the credit card processor and showing/hiding certain fields based on what the user selects in the form.
