### PR TITLE
Allow user-specified element.fail callback to override the element and/or message being fed down to addError.

### DIFF
--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -38,8 +38,8 @@
           .live('element:validate:before', function (eventData) { clientSideValidations.callbacks.element.before($(this), eventData); })
           .live('element:validate:fail',   function (eventData, message) {
             var element = $(this);
-            clientSideValidations.callbacks.element.fail(element, message, function () {
-              addError(element, message);
+            clientSideValidations.callbacks.element.fail(element, message, function (e, m) {
+              addError(e || element, m || message);
             }, eventData); })
           .live('element:validate:pass',   function (eventData) {
             var element = $(this);


### PR DESCRIPTION
Hi.

I wanted to be able to wrap all error messages displayed by client_side_validations with a "This {error}." template so my messages looked like "This can't be blank." rather than "can't be blank". The simplest way I could see was to do something like this in my callback:

clientSideValidations.callbacks.element.fail = function(element, message, addError, eventData) {
  addError(element, I18n.t('forms.inline_error', { error: message }));
}; 

Unfortunately, the addError function passed into the callback picks up the element and message from the closure, with no way to override them. I've added a couple of arguments to this function which, if not supplied, will default back to using the element and message from the closure.

What do you think?
