### PR TITLE
Proposed Change to Correct Issue #155

### DIFF
--- a/lib/client_side_validations.rb
+++ b/lib/client_side_validations.rb
@@ -1,4 +1,10 @@
 module ClientSideValidations
+  module Config 
+    class << self
+      attr_accessor :uniqueness_validator_disabled
+      @uniqueness_validator_disabled = false
+    end
+  end
 end
 
 require 'client_side_validations/active_model'  if defined?(::ActiveModel)

--- a/lib/client_side_validations/active_model.rb
+++ b/lib/client_side_validations/active_model.rb
@@ -23,7 +23,7 @@ module ClientSideValidations::ActiveModel
           validator_hash = attr[1].inject({}) do |kind_hash, validator|
             client_side_hash = validator.client_side_hash(self, attr[0])
             # Yeah yeah, #new_record? is not part of ActiveModel :p
-            if (can_use_for_client_side_validation?(client_side_hash, validator))
+            if can_use_for_client_side_validation?(client_side_hash, validator) && uniqueness_validations_allowed_or_not_applicable?(validator)
               kind_hash.merge!(validator.kind => client_side_hash.except(:on))
             else
               kind_hash.merge!({})
@@ -45,6 +45,10 @@ module ClientSideValidations::ActiveModel
 
     def can_use_for_client_side_validation?(client_side_hash, validator)
       ((self.respond_to?(:new_record?) && validator.options[:on] == (self.new_record? ? :create : :update)) || validator.options[:on].nil?) && validator.kind != :block
+    end
+
+    def uniqueness_validations_allowed_or_not_applicable?(validator)
+      validator.kind != :uniqueness || !ClientSideValidations::Config.uniqueness_validator_disabled
     end
   end
 end

--- a/lib/client_side_validations/middleware.rb
+++ b/lib/client_side_validations/middleware.rb
@@ -11,11 +11,11 @@ module ClientSideValidations
       end
 
       def call(env)
-        case env['PATH_INFO']
-        when %r{\/validators\/(\w+)}
-          "::ClientSideValidations::Middleware::#{$1.camelize}".constantize.new(env).response
-        else
+        matches = /^\/validators\/(\w+)$/.match(env['PATH_INFO'])
+        if !matches || (matches[1] == 'uniqueness' && Config.uniqueness_validator_disabled)
           @app.call(env)
+        else 
+          "::ClientSideValidations::Middleware::#{matches[1].camelize}".constantize.new(env).response
         end
       end
     end

--- a/lib/generators/templates/client_side_validations/initializer.rb
+++ b/lib/generators/templates/client_side_validations/initializer.rb
@@ -1,5 +1,8 @@
 # ClientSideValidations Initializer
 
+# Uncomment the line below if you would like to disable uniqueness validations
+# ClientSideValidations::Config.uniqueness_validator_disabled = true
+
 require 'client_side_validations/simple_form' if defined?(::SimpleForm)
 require 'client_side_validations/formtastic'  if defined?(::Formtastic)
 

--- a/test/active_record/cases/test_middleware.rb
+++ b/test/active_record/cases/test_middleware.rb
@@ -171,5 +171,19 @@ class ClientSideValidationsActiveRecordMiddlewareTest < Test::Unit::TestCase
     assert_equal 'false', last_response.body
     assert last_response.ok?
   end
+
+  def test_uniqueness_when_uniqueness_validation_is_disabled_and_resource_exists
+    # Disable uniqueness validations
+    ClientSideValidations::Config.uniqueness_validator_disabled = true
+
+    User.create(:email => 'user@test.com')
+    get '/validators/uniqueness', { 'user[email]' => 'user@test.com', 'case_sensitive' => true }
+
+    assert_equal 'success', last_response.body
+    assert last_response.ok?
+
+    # Restore to default
+    ClientSideValidations::Config.uniqueness_validator_disabled = false
+  end
 end
 


### PR DESCRIPTION
Note: I broke pull request https://github.com/bcardarella/client_side_validations/pull/165 somehow when I was rebasing my commits into one, so this is a resubmit. All issues raised in the previous pull request are addressed here.

This change addresses a security vulnerability in which, once this gem is installed, any column of any AR model can have its records scanned for the presence of a value in a given column -- thereby divulging potentially confidential information with zero access controls.

Since it's clearly not feasible to include middleware-based authentication/authorization without vastly expanding the scope of this project, it was proposed that users be able to turn off uniqueness validations entirely as needed on a per-application basis. This pull request adds this capability.

To be sure, there may be less extreme solutions out there (and thus there's definitely more work to be done here), but I am offering this code primarily because I believe this option should be among the ones client_side_validation ultimately offers, it is a simple and complete fix, and we are developing this code anyway for our organization.

A textual summary of the changes made can be found on the issues page, but the diff is fairly self-explanatory.

Best,
Mike
