### PR TITLE
added failing test case for converting complex regex to json

### DIFF
--- a/test/core_ext/cases/test_core_ext.rb
+++ b/test/core_ext/cases/test_core_ext.rb
@@ -22,6 +22,14 @@ class CoreExtTest < Test::Unit::TestCase
   def test_regexp_to_json
     assert_equal "/^$/", /\A\Z/.to_json(nil)
   end
+  
+  def test_complex_regexp_to_json
+    assert_equal URI::regexp(['http','https']), URI::regexp(['http','https']).to_json(nil)
+  end
+
+  def test_complex_regexp_encode_json
+    assert_equal URI::regexp(['http','https']), URI::regexp(['http','https']).encode_json(nil)
+  end
 
   def test_regexp_encode_json
     assert_equal "//", //.encode_json(nil)


### PR DESCRIPTION
Failing test case for issue #173, "validates format with complex regex generates invalid json". Let me know if there's anything I can do to help you replicate the issue or troubleshoot it. Thanks.
