### PR TITLE
#186: IE global variable "Illegal Assignment" error

### DIFF
--- a/lib/client_side_validations/action_view/form_helper.rb
+++ b/lib/client_side_validations/action_view/form_helper.rb
@@ -75,8 +75,9 @@ module ClientSideValidations::ActionView::Helpers
         end
 
         content_tag(:script) do
-          "if(window['ClientSideValidations'] === undefined) window['ClientSideValidations'] = {};
-          window['#{var_name}'] = #{builder.client_side_form_settings(options, self).merge(:validators => 'validator_hash').to_json};".html_safe
+          "if(window['clientSideValidations'] === undefined) window['clientSideValidations'] = {};
+          if(window['clientSideValidations']['forms'] === undefined) window['clientSideValidations']['forms'] = {};
+          window['clientSideValidations']['forms']['#{var_name}'] = #{builder.client_side_form_settings(options, self).merge(:validators => 'validator_hash').to_json};".html_safe
         end
 
       end

--- a/test/javascript/public/test/callbacks/elementAfter.js
+++ b/test/javascript/public/test/callbacks/elementAfter.js
@@ -1,6 +1,6 @@
 module('Element Validate After Callback', {
   setup: function() {
-    window['ClientSideValidations']['new_user'] = {
+    window['clientSideValidations']['forms']['new_user'] = {
       type: 'ActionView::Helpers::FormBuilder',
       input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
       label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>',

--- a/test/javascript/public/test/callbacks/elementBefore.js
+++ b/test/javascript/public/test/callbacks/elementBefore.js
@@ -1,6 +1,6 @@
 module('Element Validate Before Callback', {
   setup: function() {
-    window['ClientSideValidations']['new_user'] = {
+    window['clientSideValidations']['forms']['new_user'] = {
       type: 'ActionView::Helpers::FormBuilder',
       input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
       label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>',

--- a/test/javascript/public/test/callbacks/elementFail.js
+++ b/test/javascript/public/test/callbacks/elementFail.js
@@ -1,6 +1,6 @@
 module('Element Validate Fail Callback', {
   setup: function() {
-    window['ClientSideValidations']['new_user'] = {
+    window['clientSideValidations']['forms']['new_user'] = {
       type: 'ActionView::Helpers::FormBuilder',
       input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
       label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>',

--- a/test/javascript/public/test/callbacks/elementPass.js
+++ b/test/javascript/public/test/callbacks/elementPass.js
@@ -1,6 +1,6 @@
 module('Element Validate Pass Callback', {
   setup: function() {
-    window['ClientSideValidations']['new_user'] = {
+    window['clientSideValidations']['forms']['new_user'] = {
       type: 'ActionView::Helpers::FormBuilder',
       input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
       label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>',

--- a/test/javascript/public/test/callbacks/formAfter.js
+++ b/test/javascript/public/test/callbacks/formAfter.js
@@ -1,6 +1,6 @@
 module('Form Validate After Callback', {
   setup: function() {
-    window['ClientSideValidations']['new_user'] = {
+    window['clientSideValidations']['forms']['new_user'] = {
       type: 'ActionView::Helpers::FormBuilder',
       input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
       label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>',

--- a/test/javascript/public/test/callbacks/formBefore.js
+++ b/test/javascript/public/test/callbacks/formBefore.js
@@ -1,6 +1,6 @@
 module('Form Validate Before Callback', {
   setup: function() {
-    window['ClientSideValidations']['new_user'] = {
+    window['clientSideValidations']['forms']['new_user'] = {
       type: 'ActionView::Helpers::FormBuilder',
       input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
       label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>',

--- a/test/javascript/public/test/callbacks/formFail.js
+++ b/test/javascript/public/test/callbacks/formFail.js
@@ -1,6 +1,6 @@
 module('Form Validate Fail Callback', {
   setup: function() {
-    window['ClientSideValidations']['new_user'] = {
+    window['clientSideValidations']['forms']['new_user'] = {
       type: 'ActionView::Helpers::FormBuilder',
       input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
       label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>',

--- a/test/javascript/public/test/callbacks/formPass.js
+++ b/test/javascript/public/test/callbacks/formPass.js
@@ -1,6 +1,6 @@
 module('Form Validate Pass Callback', {
   setup: function() {
-    window['ClientSideValidations']['new_user'] = {
+    window['clientSideValidations']['forms']['new_user'] = {
       type: 'ActionView::Helpers::FormBuilder',
       input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
       label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>',

--- a/test/javascript/public/test/form_builders/validateForm.js
+++ b/test/javascript/public/test/form_builders/validateForm.js
@@ -1,6 +1,6 @@
 module('Validate Form', {
   setup: function() {
-    window['ClientSideValidations']['new_user'] = {
+    window['clientSideValidations']['forms']['new_user'] = {
       type: 'ActionView::Helpers::FormBuilder',
       input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
       label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>',

--- a/test/javascript/public/test/form_builders/validateFormtastic.js
+++ b/test/javascript/public/test/form_builders/validateFormtastic.js
@@ -1,6 +1,6 @@
 module('Validate Formtastic', {
   setup: function() {
-    window['ClientSideValidations']['new_user'] = {
+    window['clientSideValidations']['forms']['new_user'] = {
       type: 'Formtastic::FormBuilder',
       inline_error_class: 'inline-errors',
       validators: {

--- a/test/javascript/public/test/form_builders/validateNestedForm.js
+++ b/test/javascript/public/test/form_builders/validateNestedForm.js
@@ -1,6 +1,6 @@
 module('Validate Form', {
   setup: function() {
-    window['ClientSideValidations']['new_user'] = {
+    window['clientSideValidations']['forms']['new_user'] = {
       type: 'NestedForm::Builder',
       input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
       label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>',

--- a/test/javascript/public/test/form_builders/validateNestedFormtastic.js
+++ b/test/javascript/public/test/form_builders/validateNestedFormtastic.js
@@ -1,6 +1,6 @@
 module('Validate Nested Formtastic', {
   setup: function() {
-    window['ClientSideValidations']['new_user'] = {
+    window['clientSideValidations']['forms']['new_user'] = {
       type: 'NestedForm::FormtasticBuilder',
       inline_error_class: 'inline-errors',
       validators: {

--- a/test/javascript/public/test/form_builders/validateNestedSimpleForm.js
+++ b/test/javascript/public/test/form_builders/validateNestedSimpleForm.js
@@ -1,6 +1,6 @@
 module('Validate Nested SimpleForm', {
   setup: function() {
-    window['ClientSideValidations']['new_user'] = {
+    window['clientSideValidations']['forms']['new_user'] = {
       type: 'NestedForm::SimpleBuilder',
       error_class: 'error',
       error_tag: 'span',

--- a/test/javascript/public/test/form_builders/validateSimpleForm.js
+++ b/test/javascript/public/test/form_builders/validateSimpleForm.js
@@ -1,6 +1,6 @@
 module('Validate SimpleForm', {
   setup: function() {
-    window['ClientSideValidations']['new_user'] = {
+    window['clientSideValidations']['forms']['new_user'] = {
       type: 'SimpleForm::FormBuilder',
       error_class: 'error',
       error_tag: 'span',

--- a/test/javascript/public/test/settings.js
+++ b/test/javascript/public/test/settings.js
@@ -13,4 +13,5 @@ $(document).bind('submit', function(e) {
   }
 });
 
-if(window['ClientSideValidations'] === undefined) window['ClientSideValidations'] = {};
+if(window['clientSideValidations'] === undefined) window['clientSideValidations'] = {};
+if(window['clientSideValidations']['forms'] === undefined) window['clientSideValidations']['forms'] = {};

--- a/test/javascript/public/test/validateElement.js
+++ b/test/javascript/public/test/validateElement.js
@@ -1,6 +1,6 @@
 module('Validate Element', {
   setup: function() {
-    window['ClientSideValidations']['new_user'] = {
+    window['clientSideValidations']['forms']['new_user'] = {
       type: 'ActionView::Helpers::FormBuilder',
       input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
       label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>',
@@ -163,7 +163,7 @@ test("Don't validate confirmation when not a validatable input", function() {
         id: 'user_2_password_confirmation',
         type: 'password'
       }))
-  window['ClientSideValidations']['new_user_2'] = {
+  window['clientSideValidations']['forms']['new_user_2'] = {
     type: 'ActionView::Helpers::FormBuilder',
     input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
     label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>',

--- a/test/javascript/public/test/validators/uniqueness.js
+++ b/test/javascript/public/test/validators/uniqueness.js
@@ -1,6 +1,6 @@
 module('Uniqueness options', {
   setup: function() {
-    window['ClientSideValidations']['new_user'] = {
+    window['clientSideValidations']['forms']['new_user'] = {
       type: 'ActionView::Helpers::FormBuilder',
       input_tag: '<div class="field_with_errors"><span id="input_tag" /><label class="message"></label></div>',
       label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>',

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -7,13 +7,14 @@
  * http://www.opensource.org/licenses/mit-license.php
  */
 
-if(window['ClientSideValidations'] === undefined) window['ClientSideValidations'] = {};
+if(window['clientSideValidations'] === undefined) window['clientSideValidations'] = {};
+if(window['clientSideValidations']['forms'] === undefined) window['clientSideValidations']['forms'] = {};
 
 (function ($) {
   $.fn.validate = function () {
     return this.filter('form[data-validate]').each(function () {
       var form = $(this),
-          settings = window['ClientSideValidations'][form.attr('id')],
+          settings = window['clientSideValidations']['forms'][form.attr('id')],
           addError = function (element, message) {
             clientSideValidations.formBuilders[settings.type].add(element, settings, message);
           },


### PR DESCRIPTION
Fix for #186.

I moved the globals into the namespace ClientSideValidations, and fixed the tests so that they'd use this namespace too. 

I haven't introduced any new tests, because this isn't an especially testable scenario: the only thing I can test is whether the global name is the same as the form id, and all the tests already assume that isn't the case.

Thanks.
