### PR TITLE
#186 addendum: don't clobber the parent namespace

### DIFF
--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -123,6 +123,7 @@
 })(jQuery);
 
 if (window['clientSideValidations'] === undefined) window['clientSideValidations'] = {};
+if (window['clientSideValidations']['forms'] === undefined) window['clientSideValidations']['forms'] = {};
 
 jQuery.extend(window['clientSideValidations'], {
   validators: {


### PR DESCRIPTION
Additional commit for #186. Now we conditionally define the parent namespace, and then extend it, instead of just overwriting the whole thing if it already existed (which would only happen if we were loading in the footer).
