### PR TITLE
Changed the 404 return in middleware.rb to a 204

### DIFF
--- a/lib/client_side_validations/middleware.rb
+++ b/lib/client_side_validations/middleware.rb
@@ -44,7 +44,7 @@ module ClientSideValidations
 
       def response
         if is_unique?
-          self.status = 404
+          self.status = 204
           self.body   = 'true'
         else
           self.status = 200


### PR DESCRIPTION
Most users are using ajax to handle errors. Using 204 allows users to check on the different status codes instead of needing an error handling check strictly for handling this uniqueness error case.
