### PR TITLE
fields_for incorrectly assumed that *args would not be nil

### DIFF
--- a/lib/client_side_validations/action_view/form_helper.rb
+++ b/lib/client_side_validations/action_view/form_helper.rb
@@ -41,9 +41,9 @@ module ClientSideValidations::ActionView::Helpers
       options[:html][:validate] = true if options[:validate]
     end
 
-    def fields_for(record_or_name_or_array, *args, &block)
+    def fields_for(record_or_name_or_array, record_object = nil, options = {}, &block)
       output = super
-      @validators.merge!(args.last[:validators]) if @validators
+      @validators.merge!(options[:validators]) if @validators
       output
     end
 


### PR DESCRIPTION
The rails signature for fields_for allows for options to not be specified. Therefore, it's possible that there are no arguments passed in past the first one.
