### PR TITLE
support for nested attributes with dynamic number of elements

### DIFF
--- a/coffeescript/rails.validations.coffee
+++ b/coffeescript/rails.validations.coffee
@@ -60,7 +60,11 @@ $.fn.isValid = (validators) ->
   if obj.is('form')
     validateForm(obj, validators)
   else
-    validateElement(obj, validators[@[0].name])
+    validateElement(obj, validatorsFor(@[0].name, validators))
+
+validatorsFor = (name, validators) ->
+  name = name.replace(/_attributes\]\[\d+\]/g,"_attributes][]")
+  validators[name]
 
 validateForm = (form, validators) ->
   form.trigger('form:validate:before')

--- a/lib/client_side_validations/action_view/form_builder.rb
+++ b/lib/client_side_validations/action_view/form_builder.rb
@@ -81,7 +81,8 @@ module ClientSideValidations::ActionView::Helpers
       if @options[:validate] && options[:validate] != false && validators = filter_validators(method, options[:validate])
         options.merge!("data-validate" => true)
         name = options[:name] || "#{@object_name}[#{method}]"
-
+        child_index = @options[:child_index] ? "(\\d+|#{Regexp.escape(@options[:child_index])})" : "\\d+"
+        name = name.gsub(/_attributes\]\[#{child_index}\]/, '_attributes][]')
         @options[:validators].merge!("#{name}#{options[:multiple] ? "[]" : nil}" => validators)
       end
     end

--- a/test/action_view/cases/test_helpers.rb
+++ b/test/action_view/cases/test_helpers.rb
@@ -208,6 +208,37 @@ class ClientSideValidations::ActionViewHelpersTest < ActionView::TestCase
     assert_equal expected, output_buffer
   end
 
+  def test_nested_fields_for_with_nested_attributes
+    form_for(@post, :validate => true) do |f|
+      concat f.fields_for(:comments, [@comment]) { |c|
+        concat c.text_field(:title)
+      }
+    end
+
+    validators = {'post[comments_attributes][][title]' => {:presence => {:message => "can't be blank"}}}
+    expected =  whole_form("/posts/123", "edit_post_123", "edit_post", :method => "put", :validators => validators) do
+      %{<input data-validate="true" id="post_comments_attributes_0_title" name="post[comments_attributes][0][title]" size="30" type="text" />}
+    end
+
+    assert_equal expected, output_buffer
+  end
+
+  def test_nested_fields_for_with_nested_attributes_with_child_index
+    form_for(@post, :validate => true) do |f|
+      concat f.fields_for(:comments, [Comment.new], :child_index => '__INDEX__') { |c|
+        concat c.text_field(:title)
+      }
+    end
+
+    validators = {'post[comments_attributes][][title]' => {:presence => {:message => "can't be blank"}}}
+    expected =  whole_form("/posts/123", "edit_post_123", "edit_post", :method => "put", :validators => validators) do
+      %{<input data-validate="true" id="post_comments_attributes___INDEX___title" name="post[comments_attributes][__INDEX__][title]" size="30" type="text" />}
+    end
+
+    assert_equal expected, output_buffer
+  end
+
+
   def test_nested_fields_for_dont_overwrite_validation_with_inheritance
     form_for(@post, :validate => true) do |f|
       concat f.fields_for(:comment, @comment, :validate => false) { |c|

--- a/test/javascript/public/test/validateElement.js
+++ b/test/javascript/public/test/validateElement.js
@@ -8,7 +8,8 @@ module('Validate Element', {
         'user[name]':{"presence":{"message": "must be present"}, "format":{"message":"is invalid","with":/\d+/}},
         'user[password]':{"confirmation":{"message": "must match confirmation"}},
         'user[agree]':{"acceptance": {"message": "must be accepted"}},
-        'user[email]':{"uniqueness":{"message": "must be unique"},"presence":{"message": "must be present"}}
+        'user[email]':{"uniqueness":{"message": "must be unique"},"presence":{"message": "must be present"}},
+        'user[phone_numbers_attributes][][number]':{"presence":{"message": "must be present"}}
       }
     }
 
@@ -54,7 +55,20 @@ module('Validate Element', {
           'data-validate': 'true',
           type: 'text'
         }))
-
+        .append($('<label for="user_phone_numbers_attributes_0_number">Phone Number</label>'))
+        .append($('<input />', {
+          name: 'user[phone_numbers_attributes][0][number]',
+          id: 'user_phone_numbers_attributes_0_number',
+          'data-validate': 'true',
+          type: 'text'
+        }))
+        .append($('<label for="user_phone_numbers_attributes_1_number">Phone Number</label>'))
+        .append($('<input />', {
+          name: 'user[phone_numbers_attributes][1][number]',
+          id: 'user_phone_numbers_attributes_1_number',
+          'data-validate': 'true',
+          type: 'text'
+        }))
     $('form#new_user').validate();
   }
 });
@@ -85,6 +99,22 @@ test('Validate when focusout on confirmation', function() {
   password.val('password');
   confirmation.trigger('focusout');
   ok(password.parent().hasClass('field_with_errors'));
+  ok(label.parent().hasClass('field_with_errors'));
+});
+
+test('Validate nested attributes', function() {
+  var form = $('form#new_user'), input, label;
+  
+  input = form.find('input#user_phone_numbers_attributes_1_number');
+  label = $('label[for="user_phone_numbers_attributes_1_number"]');
+  input.trigger('focusout');
+  ok(input.parent().hasClass('field_with_errors'));
+  ok(label.parent().hasClass('field_with_errors'));
+
+  input = form.find('input#user_phone_numbers_attributes_0_number');
+  label = $('label[for="user_phone_numbers_attributes_0_number"]');
+  input.trigger('focusout');
+  ok(input.parent().hasClass('field_with_errors'));
   ok(label.parent().hasClass('field_with_errors'));
 });
 

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -1,5 +1,5 @@
 (function() {
-  var $, validateElement, validateForm,
+  var $, validateElement, validateForm, validatorsFor,
     __indexOf = Array.prototype.indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
 
   $ = jQuery;
@@ -104,8 +104,13 @@
     if (obj.is('form')) {
       return validateForm(obj, validators);
     } else {
-      return validateElement(obj, validators[this[0].name]);
+      return validateElement(obj, validatorsFor(this[0].name, validators));
     }
+  };
+
+  validatorsFor = function(name, validators) {
+    name = name.replace(/_attributes\]\[\d+\]/g, "_attributes][]");
+    return validators[name];
   };
 
   validateForm = function(form, validators) {


### PR DESCRIPTION
Rebased as one commit.

Since the validations for each nested attribute are the same, there is no need to have them repeated for each model. Instead, the validations can be specified once for all the nested attributes and then applied to fields at any index.

For example, given users that accepts nested attributes for emails, the form will contain the following fields,

```
user[email_attributes][0][email_address]
user[email_attributes][1][email_address]
user[email_attributes][2][email_address]
user[email_attributes][N][email_address]
```

we can specify validation for all email_address fields simply as,

```
user[email_attributes][][email_address]
```

This not only sends less data to the client but also works with dynamic forms (i.e. press + to add another email address field).
