### PR TITLE
nil.[] exception fix when using fields_for

### DIFF
--- a/lib/client_side_validations/action_view/form_helper.rb
+++ b/lib/client_side_validations/action_view/form_helper.rb
@@ -49,11 +49,11 @@ module ClientSideValidations::ActionView::Helpers
       options[:html][:validate] = true if options[:validate]
     end
 
-    #def fields_for(record_or_name_or_array, *args, &block)
-    #  output = super
-      # @validators.merge!(args.last[:validators]) if @validators
-     # output
-    # end
+    def fields_for(record_or_name_or_array, *args, &block)
+      output = super
+      @validators.merge!(args.last ? args.last[:validators] : {}) if @validators
+      output
+    end
 
     private
 


### PR DESCRIPTION
Issue:  "The error occurred while evaluating nil.[]" when I use <% fields_for :some_object do |blah| %> for some reason. 

Fix: Merge an empty hash if args.last comes in as nil fixes this error. For some reason not merging anything breaks the front-end javascript. Fixes nil.[] issue with fields_for.
