### PR TITLE
Fix for nil.[] error that is thrown when fields_for is used without a form_for

### DIFF
--- a/lib/client_side_validations/action_view/form_helper.rb
+++ b/lib/client_side_validations/action_view/form_helper.rb
@@ -51,7 +51,7 @@ module ClientSideValidations::ActionView::Helpers
 
     def fields_for(record_or_name_or_array, *args, &block)
       output = super
-      @validators.merge!(args.last[:validators]) if @validators
+      @validators.merge!(args.last ? args.last[:validators] : {}) if @validators
       output
     end
 

--- a/test/action_view/cases/test_helpers.rb
+++ b/test/action_view/cases/test_helpers.rb
@@ -198,11 +198,16 @@ class ClientSideValidations::ActionViewHelpersTest < ActionView::TestCase
       concat f.fields_for(:comment, @comment) { |c|
         concat c.text_field(:title)
       }
+      
+      concat fields_for(:another_comment) { |c|
+        concat c.text_field(:title)
+      }
+      
     end
 
     validators = {'post[comment][title]' => {:presence => {:message => "can't be blank"}}}
     expected =  whole_form("/posts/123", "edit_post_123", "edit_post", :method => "put", :validators => validators) do
-      %{<input data-validate="true" id="post_comment_title" name="post[comment][title]" size="30" type="text" />}
+      %{<input data-validate="true" id="post_comment_title" name="post[comment][title]" size="30" type="text" /><input id="another_comment_title" name="another_comment[title]" size="30" type="text" />}
     end
 
     assert_equal expected, output_buffer


### PR DESCRIPTION
Added test to prove that this bug exists and that the fix works for it :-)
