### PR TITLE
Fix for nil.[] error that is thrown when fields_for is used without a form_for

### DIFF
--- a/lib/client_side_validations/action_view/form_helper.rb
+++ b/lib/client_side_validations/action_view/form_helper.rb
@@ -51,7 +51,7 @@ module ClientSideValidations::ActionView::Helpers
 
     def fields_for(record_or_name_or_array, *args, &block)
       output = super
-      @validators.merge!(args.last[:validators]) if @validators
+      @validators.merge!(args.last ? args.last[:validators] : {}) if @validators
       output
     end
 

--- a/test/action_view/cases/test_helpers.rb
+++ b/test/action_view/cases/test_helpers.rb
@@ -207,6 +207,22 @@ class ClientSideValidations::ActionViewHelpersTest < ActionView::TestCase
 
     assert_equal expected, output_buffer
   end
+  
+  
+  def test_orphaned_nested_fields_for_with_no_inherit_validation_settings
+    form_for(@post, :validate => true) do |f|
+      concat fields_for(:comment) { |c|
+        concat c.text_field(:title)
+      }
+    end
+
+    expected =  whole_form("/posts/123", "edit_post_123", "edit_post", :method => "put", :validators => {}) do
+      %{<input id="comment_title" name="comment[title]" size="30" type="text" />}
+    end
+
+    assert_equal expected, output_buffer
+  end
+  
 
   def test_nested_fields_for_dont_overwrite_validation_with_inheritance
     form_for(@post, :validate => true) do |f|


### PR DESCRIPTION
Put test into second concern as requested.
