### PR TITLE
Add the ability to not validate a numeric field if it can be empty.

### DIFF
--- a/lib/client_side_validations/active_model/numericality.rb
+++ b/lib/client_side_validations/active_model/numericality.rb
@@ -10,6 +10,7 @@ module ClientSideValidations::ActiveModel
     def client_side_hash(model, attribute)
       options = self.options.dup
       hash    = { :messages => { :numericality => model.errors.generate_message(attribute, :not_a_number, options) } }
+      hash[:allow_nil]  = true if options[:allow_nil]
 
       if options[:only_integer]
         hash[:messages][:only_integer] = model.errors.generate_message(attribute, :not_an_integer, options)

--- a/test/active_model/cases/test_validations.rb
+++ b/test/active_model/cases/test_validations.rb
@@ -39,6 +39,7 @@ class ActiveModel::ValidationsTest < ClientSideValidations::ActiveModelTestBase
     person = new_person do |p|
       p.validates_length_of :first_name, :is => 10, :allow_blank => true
       p.validates_format_of :first_name, :with => //, :allow_blank => true
+      p.validates_numericality_of :age, :allow_nil => true
     end
     expected_hash = {
       :first_name => {
@@ -51,6 +52,14 @@ class ActiveModel::ValidationsTest < ClientSideValidations::ActiveModelTestBase
           :message => 'is invalid',
           :with => //,
           :allow_blank => true
+        }
+      },
+      :age => {
+        :numericality => {
+          :messages => {
+            :numericality => "is not a number"
+          },
+          :allow_nil=>true
         }
       }
     }

--- a/test/javascript/public/test/validators/numericality.js
+++ b/test/javascript/public/test/validators/numericality.js
@@ -149,3 +149,8 @@ test('when only allowing even values and the value is odd', function() {
   equal(ClientSideValidations.validators.local.numericality(element, options), "failed validation");
 });
 
+test('when allowing nil', function() {
+  var element = $('<input type="text" />');
+  var options = { messages: { numericality: "failed validation" }, allow_nil: true };
+  equal(ClientSideValidations.validators.local.numericality(element, options), undefined);
+});

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -169,7 +169,9 @@ var ClientSideValidations = {
         }
       },
       numericality: function (element, options) {
-        if (!/^-?(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d*)?$/.test(element.val())) {
+        if (element.val() === "" && options.allow_nil === true) {
+          return;
+        } else if (!/^-?(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d*)?$/.test(element.val())) {
           return options.messages.numericality;
         }
 


### PR DESCRIPTION
If one does a :

```
  validates_numericality_of :foo, :allow_nil => true
```

The javascript validation won't let you submit the form if the field is empty.
