### PR TITLE
Use 200 HTTP status code for server-side uniqueness validation.

### DIFF
--- a/lib/client_side_validations/middleware.rb
+++ b/lib/client_side_validations/middleware.rb
@@ -43,13 +43,8 @@ module ClientSideValidations
       REGISTERED_ORMS = []
 
       def response
-        if is_unique?
-          self.status = 404
-          self.body   = 'true'
-        else
-          self.status = 200
-          self.body   = 'false'
-        end
+        self.status = 200
+        self.body = is_unique? ? 'true' : 'false'
         super
       end
 


### PR DESCRIPTION
“The 4xx class of status code is intended for cases in which the client seems to have erred.” — [RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4)
