### PR TITLE
Better UI for `attribute confirmation` fields

### DIFF
--- a/test/javascript/public/test/validateElement.js
+++ b/test/javascript/public/test/validateElement.js
@@ -83,25 +83,10 @@ test('Validate when focusout on confirmation', function() {
   var label = $('label[for="user_password"]');
 
   password.val('password');
+  confirmation.val('not matching password')
   confirmation.trigger('focusout');
   ok(password.parent().hasClass('field_with_errors'));
   ok(label.parent().hasClass('field_with_errors'));
-});
-
-test('Validate when keyup on confirmation', function() {
-  var form = $('form#new_user'), password = form.find('input#user_password'), confirmation = form.find('input#user_password_confirmation');
-  var label = $('label[for="user_password"]');
-
-  password.val('password');
-
-  confirmation.trigger('keyup');
-  ok(password.parent().hasClass('field_with_errors'));
-  ok(label.parent().hasClass('field_with_errors'));
-
-  confirmation.val('password')
-  confirmation.trigger('keyup');
-  ok(!password.parent().hasClass('field_with_errors'));
-  ok(!label.parent().hasClass('field_with_errors'));
 });
 
 test('Forcing remote validators to run last', function() {

--- a/test/javascript/public/test/validators/confirmation.js
+++ b/test/javascript/public/test/validators/confirmation.js
@@ -23,3 +23,12 @@ test('when values do not match', function() {
   password_confirmation_element.val('bad test');
   equal(ClientSideValidations.validators.local.confirmation(password_element, options), "failed validation");
 });
+
+test('when the confirmation field is blank', function() {
+  var password_element = $('#password');
+  var password_confirmation_element = $('#password_confirmation');
+  var options = { message: "failed validation" };
+  password_element.val('test');
+  password_confirmation_element.val('');
+  equal(ClientSideValidations.validators.local.confirmation(password_element, options), undefined);
+});

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -59,9 +59,6 @@
               .live('focusout', function () {
                 element.data('changed', true).isValid(settings.validators);
               })
-              .live('keyup', function () {
-                element.data('changed', true).isValid(settings.validators);
-              });
           }
         });
 
@@ -265,7 +262,8 @@ var ClientSideValidations = {
         }
       },
       confirmation: function (element, options) {
-        if (element.val() !== jQuery('#' + element.attr('id') + '_confirmation').val()) {
+        var confirmationFieldValue = jQuery('#' + element.attr('id') + '_confirmation').val();
+        if (confirmationFieldValue && element.val() !== confirmationFieldValue) {
           return options.message;
         }
       }


### PR DESCRIPTION
This pull request provides a better UI for confirmation fields – specifically it now validates `attribute` / `attribute_confirmation` only after tabbing out of the `attribute_confirmation` field. It involves two changes:
1. Don't trigger validation if the `attribute_confirmation` field is blank.
   Currently as soon as you focus on the `attribute_confirmation` field, the corresponding `attribute` field registers an error – before the user has even had a chance to type anything. That sorta sucks.
2. Don't validate the `attribute_confirmation` field on keyup.
   I'm not sure keyup makes sense here. We don't want the user seeing an error until they are finished typing and have blurred off the field.

Unfortunately, this _does not_ fix the issue of the validation registering (at least arguably) on the wrong field. I believe the expected behavior would be for the validation to display on `attribute_confirmation` rather than `attribute`. As @bcardarella pointed out, however, this is how Rails validations work and so this feels like the wrong place to be addressing that issue.

@bcardarella: I've updated the tests as well. Let me know if you'd like me to make any tweaks.
