### PR TITLE
Checkbox acceptance validation causes checkbox to uncheck immediately

### DIFF
--- a/coffeescript/rails.validations.coffee
+++ b/coffeescript/rails.validations.coffee
@@ -43,7 +43,11 @@ $.fn.validate = ->
     }
 
     # Checkboxes - Live events don't support filter
-    form.find('[data-validate="true"]:checkbox').live('click', -> $(@).isValid(settings.validators))
+    form.find('[data-validate="true"]:checkbox').live('click', ->
+       $(@).isValid(settings.validators)
+       # If we don't return true here the checkbox will immediately uncheck itself.
+       return true
+    )
 
     # Inputs for confirmations
     form.find('[id*=_confirmation]').each ->

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -1,13 +1,3 @@
-
-/*
-  Rails 3 Client Side Validations - v3.2.0.beta.2
-  https://github.com/bcardarella/client_side_validations
-
-  Copyright (c) 2012 Brian Cardarella
-  Licensed under the MIT license
-  http://www.opensource.org/licenses/mit-license.php
-*/
-
 (function() {
   var $, validateElement, validateForm,
     __indexOf = Array.prototype.indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
@@ -82,7 +72,8 @@
         form.find('[data-validate="true"]:input:enabled:not(:radio)').live(event, binding);
       }
       form.find('[data-validate="true"]:checkbox').live('click', function() {
-        return $(this).isValid(settings.validators);
+        $(this).isValid(settings.validators);
+        return true;
       });
       return form.find('[id*=_confirmation]').each(function() {
         var binding, confirmationElement, element, event, _ref3, _results;


### PR DESCRIPTION
I did not see an appropriate branch to make this pull request against since I forked off of master and this only seems to be a problem in master.

I ran into a problem with a checkbox validator where the checking the checkbox would immediately cause the checkbox to uncheck itself.  I was able to trace back the problem to not returning true from the checkbox click handler.  I'm not sure why this is a problem now since it didn't look like true was forcibly returned previously either but this change fixed the problem for me.

No tests broke as a result.  I did not include a test because I didn't see any browser tests and it seems like this may be a place where the existing JS testing is not enough?
