### PR TITLE
Bug Fix - fields_for view helper is broken when no validators are passed - Here is the fix

### DIFF
--- a/lib/client_side_validations/action_view/form_helper.rb
+++ b/lib/client_side_validations/action_view/form_helper.rb
@@ -51,7 +51,7 @@ module ClientSideValidations::ActionView::Helpers
 
     def fields_for(record_or_name_or_array, *args, &block)
       output = super
-      @validators.merge!(args.last[:validators]) if @validators
+      @validators.merge!(args.last[:validators]) if @validators && !args.last[:validators].nil?
       output
     end
 


### PR DESCRIPTION
I am using fields for like this:

<%=fields_for name_prefix,widget do |widget_form| %> .. 
and I was getting the error:

can't convert nil into Hash
in here 
client_side_validations (3.1.4) lib/client_side_validations/action_view/form_helper.rb:46:in `merge!'
client_side_validations (3.1.4) lib/client_side_validations/action_view/form_helper.rb:46:in`fields_for'
