### PR TITLE
Fix validateElement to return validation result

### DIFF
--- a/coffeescript/rails.validations.coffee
+++ b/coffeescript/rails.validations.coffee
@@ -67,7 +67,7 @@ validateForm = (form, validators) ->
 
   valid = true
   form.find('[data-validate="true"]:input:enabled').each ->
-    valid = false if $(@).isValid(validators)
+    valid = false unless $(@).isValid(validators)
 
   if valid then form.trigger('form:validate:pass') else form.trigger('form:validate:fail')
 
@@ -102,7 +102,7 @@ validateElement = (element, validators) ->
       element.trigger('element:validate:pass')
 
   element.trigger('element:validate:after')
-  element.data('valid') == false ? false : true
+  element.data('valid') != false
 
 # Main hook
 # If new forms are dynamically introduced into the DOM the .validate() method

--- a/test/javascript/public/test/validateElement.js
+++ b/test/javascript/public/test/validateElement.js
@@ -294,3 +294,12 @@ test("Don't validate dynamically disabled inputs", function() {
   input.trigger('focusout');
   ok(!input.parent().hasClass('field_with_errors'));
 });
+
+test("Return validation result", function() {
+  var input = $('#user_name');
+
+  ok(!input.isValid(ClientSideValidations.forms['new_user'].validators));
+
+  input.val('123').data('changed', true);
+  ok(input.isValid(ClientSideValidations.forms['new_user'].validators));
+});

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -113,7 +113,7 @@
     form.trigger('form:validate:before');
     valid = true;
     form.find('[data-validate="true"]:input:enabled').each(function() {
-      if ($(this).isValid(validators)) return valid = false;
+      if (!$(this).isValid(validators)) return valid = false;
     });
     if (valid) {
       form.trigger('form:validate:pass');
@@ -125,7 +125,7 @@
   };
 
   validateElement = function(element, validators) {
-    var context, fn, kind, message, valid, _ref;
+    var context, fn, kind, message, valid;
     element.trigger('element:validate:before');
     if (element.data('changed') !== false) {
       valid = true;
@@ -156,9 +156,7 @@
       }
     }
     element.trigger('element:validate:after');
-    return (_ref = element.data('valid') === false) != null ? _ref : {
-      "false": true
-    };
+    return element.data('valid') !== false;
   };
 
   $(function() {


### PR DESCRIPTION
`isInvalid` works incorrectly with individual inputs. Problem is in `validateElement` method. It's return value:

``` coffeescript
element.data('valid') == false ? false : true
```

is compiled to:

``` javascript
return (_ref = element.data('valid') === false) != null ? _ref : {
  "false": true
};
```

I don't think that was intended.

I have fixed this and added tests.
