### PR TITLE
Enabled if and unless specification

### DIFF
--- a/lib/client_side_validations/active_model.rb
+++ b/lib/client_side_validations/active_model.rb
@@ -8,6 +8,10 @@ module ClientSideValidations::ActiveModel
       { :message => model.errors.generate_message(attribute, message_type, options) }.merge(options.except(*::ActiveModel::Errors::CALLBACKS_OPTIONS - [:allow_blank, :if, :unless]))
     end
 
+    def copy_conditional_attributes(to, from)
+      [:if, :unless].each { |key| to[key] = from[key] if from[key].present? }
+    end
+
     private
 
     def message_type

--- a/lib/client_side_validations/active_model/length.rb
+++ b/lib/client_side_validations/active_model/length.rb
@@ -16,6 +16,8 @@ module ClientSideValidations::ActiveModel
         end
       end
 
+      copy_conditional_attributes(hash, options)
+
       hash
     end
 

--- a/lib/client_side_validations/active_model/numericality.rb
+++ b/lib/client_side_validations/active_model/numericality.rb
@@ -23,6 +23,8 @@ module ClientSideValidations::ActiveModel
         end
       end
 
+      copy_conditional_attributes(hash, options)
+
       hash
     end
 

--- a/test/action_view/cases/test_helpers.rb
+++ b/test/action_view/cases/test_helpers.rb
@@ -355,12 +355,12 @@ class ClientSideValidations::ActionViewHelpersTest < ActionView::TestCase
     assert_equal expected, output_buffer
   end
 
-  def test_conditional_validators_should_be_filtered
+  def test_conditional_validators_should_be_filtered_based_on_symbol_condition_true
     hash = {
       :cost => {
         :presence => {
           :message => "can't be blank",
-          :unless => :do_not_validate?
+          :unless => :do_validate?
         }
       },
       :title => {
@@ -380,9 +380,182 @@ class ClientSideValidations::ActionViewHelpersTest < ActionView::TestCase
       concat f.text_field(:title)
     end
 
-    validators = {}
+    validators = {
+        'post[title]' => {:presence => {:message => "can't be blank"}}
+    }
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", :method => "put", :validators => validators) do
       %{<input id="post_cost" name="post[cost]" size="30" type="text" />} +
+      %{<input data-validate="true" id="post_title" name="post[title]" size="30" type="text" />}
+    end
+    assert_equal expected, output_buffer
+  end
+
+  def test_conditional_validators_should_be_filtered_based_on_symbol_condition_false
+    hash = {
+      :cost => {
+        :presence => {
+          :message => "can't be blank",
+          :unless => :do_not_validate?
+        }
+      },
+      :title => {
+        :presence => {
+          :message => "can't be blank",
+          :if => :do_not_validate?
+        }
+      }
+    }
+
+    @post.title = nil
+    @post.stubs(:do_not_validate?).returns(false)
+    @post.stubs(:do_validate?).returns(true)
+    @post.stubs(:client_side_validation_hash).returns(hash)
+    form_for(@post, :validate => true) do |f|
+      concat f.text_field(:cost)
+      concat f.text_field(:title)
+    end
+
+    validators = {
+        'post[cost]' => {:presence => {:message => "can't be blank"}}
+    }
+    expected = whole_form("/posts/123", "edit_post_123", "edit_post", :method => "put", :validators => validators) do
+      %{<input data-validate="true" id="post_cost" name="post[cost]" size="30" type="text" />} +
+      %{<input id="post_title" name="post[title]" size="30" type="text" />}
+    end
+    assert_equal expected, output_buffer
+  end
+
+  def test_conditional_validators_should_be_filtered_based_on_string_condition_true
+    hash = {
+      :cost => {
+        :presence => {
+          :message => "can't be blank",
+          :unless => 'true'
+        }
+      },
+      :title => {
+        :presence => {
+          :message => "can't be blank",
+          :if => 'true'
+        }
+      }
+    }
+
+    @post.title = nil
+    @post.stubs(:client_side_validation_hash).returns(hash)
+    form_for(@post, :validate => true) do |f|
+      concat f.text_field(:cost)
+      concat f.text_field(:title)
+    end
+
+    validators = {
+        'post[title]' => {:presence => {:message => "can't be blank"}}
+    }
+    expected = whole_form("/posts/123", "edit_post_123", "edit_post", :method => "put", :validators => validators) do
+      %{<input id="post_cost" name="post[cost]" size="30" type="text" />} +
+      %{<input data-validate="true" id="post_title" name="post[title]" size="30" type="text" />}
+    end
+    assert_equal expected, output_buffer
+  end
+
+  def test_conditional_validators_should_be_filtered_based_on_string_condition_false
+    hash = {
+      :cost => {
+        :presence => {
+          :message => "can't be blank",
+          :unless => 'false'
+        }
+      },
+      :title => {
+        :presence => {
+          :message => "can't be blank",
+          :if => 'false'
+        }
+      }
+    }
+
+    @post.title = nil
+    @post.stubs(:client_side_validation_hash).returns(hash)
+    form_for(@post, :validate => true) do |f|
+      concat f.text_field(:cost)
+      concat f.text_field(:title)
+    end
+
+    validators = {
+        'post[cost]' => {:presence => {:message => "can't be blank"}}
+    }
+    expected = whole_form("/posts/123", "edit_post_123", "edit_post", :method => "put", :validators => validators) do
+      %{<input data-validate="true" id="post_cost" name="post[cost]" size="30" type="text" />} +
+      %{<input id="post_title" name="post[title]" size="30" type="text" />}
+    end
+    assert_equal expected, output_buffer
+  end
+
+  def test_conditional_validators_should_be_filtered_based_on_proc_condition_true
+    hash = {
+      :cost => {
+        :presence => {
+          :message => "can't be blank",
+          :unless => Proc.new { |o| o.do_validate? }
+        }
+      },
+      :title => {
+        :presence => {
+          :message => "can't be blank",
+          :if => Proc.new { |o| o.do_validate? }
+        }
+      }
+    }
+
+    @post.title = nil
+    @post.stubs(:do_not_validate?).returns(false)
+    @post.stubs(:do_validate?).returns(true)
+    @post.stubs(:client_side_validation_hash).returns(hash)
+    form_for(@post, :validate => true) do |f|
+      concat f.text_field(:cost)
+      concat f.text_field(:title)
+    end
+
+    validators = {
+        'post[title]' => {:presence => {:message => "can't be blank"}}
+    }
+    expected = whole_form("/posts/123", "edit_post_123", "edit_post", :method => "put", :validators => validators) do
+      %{<input id="post_cost" name="post[cost]" size="30" type="text" />} +
+      %{<input data-validate="true" id="post_title" name="post[title]" size="30" type="text" />}
+    end
+    assert_equal expected, output_buffer
+  end
+
+  def test_conditional_validators_should_be_filtered_based_on_proc_condition_false
+    hash = {
+      :cost => {
+        :presence => {
+          :message => "can't be blank",
+          :unless => Proc.new { |o| o.do_not_validate? }
+        }
+      },
+      :title => {
+        :presence => {
+          :message => "can't be blank",
+          :if => Proc.new { |o| o.do_not_validate? }
+        }
+      }
+    }
+
+    @post.title = nil
+    @post.stubs(:do_not_validate?).returns(false)
+    @post.stubs(:do_validate?).returns(true)
+    @post.stubs(:client_side_validation_hash).returns(hash)
+    form_for(@post, :validate => true) do |f|
+      concat f.text_field(:cost)
+      concat f.text_field(:title)
+    end
+
+    validators = {
+        'post[cost]' => {:presence => {:message => "can't be blank"}}
+    }
+    expected = whole_form("/posts/123", "edit_post_123", "edit_post", :method => "put", :validators => validators) do
+      %{<input data-validate="true" id="post_cost" name="post[cost]" size="30" type="text" />} +
       %{<input id="post_title" name="post[title]" size="30" type="text" />}
     end
     assert_equal expected, output_buffer
@@ -579,6 +752,9 @@ class ClientSideValidations::ActionViewHelpersTest < ActionView::TestCase
     }
 
     @post.title = nil
+    # we don't have _changed? methods by default so we must stub them
+    @post.stubs(:title_changed?).returns(true)
+    @post.stubs(:cost_changed?).returns(false)
     @post.stubs(:client_side_validation_hash).returns(hash)
     form_for(@post, :validate => true) do |f|
       concat f.text_field(:cost)
@@ -613,6 +789,9 @@ class ClientSideValidations::ActionViewHelpersTest < ActionView::TestCase
     }
 
     @post.title = nil
+    # we don't have _changed? methods by default so we must stub them
+    @post.stubs(:title_changed?).returns(true)
+    @post.stubs(:cost_changed?).returns(false)
     @post.stubs(:client_side_validation_hash).returns(hash)
     form_for(@post, :validate => true) do |f|
       concat f.text_field(:cost, :validate => true)


### PR DESCRIPTION
You can specify :if or :unless (not both!) using a string, symbol
or even Proc. Seems to work for me.

Also fixed one problem in existing tests. title_changed? and
cost_changed? are not defined automatically so they must
be stubbed.

I also added tests for new functionality. It's tested only
for present validators same as other existing tests.

This pullrequest is just rebased version of #299 and original issue refs #239 hope this time it's according to your needs :)
