### PR TITLE
client_side_validations version 3.1.4 you need to use rails g client_side_validations:copy_asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ config/initializers/client_side_validations.rb
 If you are using Rails 3.1+ you'll need to use:
 
 ```
-rails g client_side_validations:copy_assets
+rails g client_side_validations:copy_asset
 ```
 
 ## Usage ##


### PR DESCRIPTION
I believe in client_side_validations version 3.1.4 you need to use the singular form of “asset”, as in:

rails g client_side_validations:copy_asset
