### PR TITLE
issue when HTML parsers would try and validate or test on the HTML tags

### DIFF
--- a/lib/client_side_validations/action_view/form_helper.rb
+++ b/lib/client_side_validations/action_view/form_helper.rb
@@ -95,9 +95,8 @@ module ClientSideValidations::ActionView::Helpers
         end
 
         content_tag(:script) do
-          "window.ClientSideValidations.forms['#{var_name}'] = #{builder.client_side_form_settings(options, self).merge(:validators => 'validator_hash').to_json};".html_safe
+          "//<![CDATA[\nwindow.ClientSideValidations.forms['#{var_name}'] = #{builder.client_side_form_settings(options, self).merge(:validators => 'validator_hash').to_json};\n//]]>".html_safe
         end
-
       end
     end
 

--- a/test/action_view/cases/helper.rb
+++ b/test/action_view/cases/helper.rb
@@ -145,7 +145,7 @@ module ActionViewTestSetup
   end
 
   def build_script_tag(html, id, validators)
-    (html || "") + %Q{<script>window.ClientSideValidations.forms['#{id}'] = #{client_side_form_settings_helper.merge(:validators => validators).to_json};</script>}
+    (html || "") + %Q{<script>//<![CDATA[\nwindow.ClientSideValidations.forms['#{id}'] = #{client_side_form_settings_helper.merge(:validators => validators).to_json};\n//]]></script>}
   end
 
   protected


### PR DESCRIPTION
When running view tests, I was getting piles of warnings like this from assert_select:

```
ignoring attempt to close div with script
 opened at byte 15673, line 411
 closed at byte 18702, line 411
 attributes at open: {"class"=>"\\\"field_with_errors\\\""}
 text around open: "ilder\",\"input_tag\":\"<div class=\\\"field_w"
 text around close: "act.processing\"}}}};</script>\n</fieldset"
```

It seems that most parsers/assert_select can't discern embedded HTML inside a script tag.
After some fiddling I added some CDATA tags on the inside of the script tag the form_helper adds to
the bottom of the form. All my JS still worked, and all my capybara tests still passed.

It's a pretty minor change.
