### PR TITLE
Minor updates to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ config/initializers/client_side_validations.rb
 If you are using Rails 3.1+ you'll need to use:
 
 ```
-rails g client_side_validations:copy_assets
+rails g client_side_validations:copy_asset
 ```
 
 ## Usage ##


### PR DESCRIPTION
Fixed a typo: Unles => Unless.

And fixed generator explanation:

rails g client_side_validations:copy_assets

Doesn't exists, it should be:

rails g client_side_validations:copy_asset
