### PR TITLE
Changed string passed to element.closest() when removing errors so that

### DIFF
--- a/coffeescript/rails.validations.coffee
+++ b/coffeescript/rails.validations.coffee
@@ -286,7 +286,7 @@ window.ClientSideValidations =
 
       remove: (element, settings) ->
         errorFieldClass = jQuery(settings.input_tag).attr('class')
-        inputErrorField = element.closest(".#{errorFieldClass}")
+        inputErrorField = element.closest(".#{errorFieldClass.replace(" ", ".")}")
         label = jQuery("label[for='#{element.attr('id')}']:not(.message)")
         labelErrorField = label.closest(".#{errorFieldClass}")
 


### PR DESCRIPTION
elements with multiple classes can have error markup removed.

(Makes it easier to customize to be compatible with twitter-bootstrap error markup).
