### PR TITLE
Utilize "allow_blank" option for uniqueness if defined

### DIFF
--- a/lib/client_side_validations/active_record/uniqueness.rb
+++ b/lib/client_side_validations/active_record/uniqueness.rb
@@ -11,6 +11,10 @@ module ClientSideValidations::ActiveRecord
         end
       end
 
+      if options[:allow_blank] == true
+        hash[:allow_blank] = true
+      end
+
       unless model.class.name.demodulize == model.class.name
         hash[:class] = model.class.name.underscore
       end


### PR DESCRIPTION
The uniquness function in js file checks for allow_blank option, but we are not setting it
in Uniqueness module.
