### PR TITLE
don't force priority_zones to nil when time_zone_select helper is used

### DIFF
--- a/lib/client_side_validations/action_view/form_builder.rb
+++ b/lib/client_side_validations/action_view/form_builder.rb
@@ -72,7 +72,7 @@ module ClientSideValidations::ActionView::Helpers
 
     def time_zone_select_with_client_side_validations(method, priority_zones = nil, options = {}, html_options = {})
       apply_client_side_validators(method, html_options)
-      time_zone_select_without_client_side_validations(method, priority_zones = nil, options, html_options)
+      time_zone_select_without_client_side_validations(method, priority_zones, options, html_options)
     end
 
   private


### PR DESCRIPTION
This looks like a copy/pasta bug, unless I'm missing something more subtle.
