### PR TITLE
Multiline regex

### DIFF
--- a/lib/client_side_validations/core_ext/regexp.rb
+++ b/lib/client_side_validations/core_ext/regexp.rb
@@ -1,6 +1,6 @@
 class Regexp
   def as_json(options = nil)
-    Regexp.new inspect.sub('\\A','^').sub('\\Z','$').sub('\\z','$').sub(/^\//,'').sub(/\/[a-z]*$/,'').gsub(/\(\?#.+\)/, '').gsub(/\(\?-\w+:/,'(').gsub(/\n/,''), self.options & 5
+    Regexp.new inspect.sub('\\A','^').sub('\\Z','$').sub('\\z','$').sub(/^\//,'').sub(/\/[a-z]*$/,'').gsub(/\(\?#.+\)/, '').gsub(/\(\?-\w+:/,'(').gsub(/\s/,''), self.options & 5
   end
 
   def to_json(options = nil)

--- a/test/core_ext/cases/test_core_ext.rb
+++ b/test/core_ext/cases/test_core_ext.rb
@@ -54,7 +54,7 @@ class CoreExtTest < Test::Unit::TestCase
   def test_multiline_regexp_as_json
     test_regexp = /
     /
-    expected_regexp = /    /
+    expected_regexp = //
     assert_equal expected_regexp, test_regexp.as_json
   end
 


### PR DESCRIPTION
Hi, I tried with next regexp `URI::regexp(%w(http https))`. JS cant' parse json your gem generate.

At first, it had some whitespaces.

At second it had `x` modifier.

So I write little patch that helps in my case.
