### PR TITLE
Provide support for :allow_blank option for validates_uniqueness.

### DIFF
--- a/lib/client_side_validations/active_record/uniqueness.rb
+++ b/lib/client_side_validations/active_record/uniqueness.rb
@@ -4,6 +4,7 @@ module ClientSideValidations::ActiveRecord
       hash = {}
       hash[:message] = model.errors.generate_message(attribute, message_type, options.except(:scope))
       hash[:case_sensitive] = options[:case_sensitive]
+      hash[:allow_blank] = options[:allow_blank] if options.key?(:allow_blank)
       hash[:id] = model.id unless model.new_record?
       if options.key?(:scope) && options[:scope].present?
         hash[:scope] = Array.wrap(options[:scope]).inject({}) do |scope_hash, scope_item|

--- a/lib/client_side_validations/mongo_mapper/uniqueness.rb
+++ b/lib/client_side_validations/mongo_mapper/uniqueness.rb
@@ -4,6 +4,7 @@ module ClientSideValidations::MongoMapper
       hash = {}
       hash[:message] = model.errors.generate_message(attribute, message_type, options.except(:scope))
       hash[:case_sensitive] = options[:case_sensitive] if options.key?(:case_sensitive)
+      hash[:allow_blank] = options[:allow_blank] if options.key?(:allow_blank)
       hash[:id] = model.id unless model.new_record?
       if options.key?(:scope) && options[:scope].present?
         hash[:scope] = Array.wrap(options[:scope]).inject({}) do |scope_hash, scope_item|

--- a/lib/client_side_validations/mongoid/uniqueness.rb
+++ b/lib/client_side_validations/mongoid/uniqueness.rb
@@ -4,6 +4,7 @@ module ClientSideValidations::Mongoid
       hash = {}
       hash[:message] = model.errors.generate_message(attribute, message_type, options.except(:scope))
       hash[:case_sensitive] = options[:case_sensitive] if options.key?(:case_sensitive)
+      hash[:allow_blank] = options[:allow_blank] if options.key?(:allow_blank)
       hash[:id] = model.id unless model.new_record?
       if options.key?(:scope) && options[:scope].present?
         hash[:scope] = Array.wrap(options[:scope]).inject({}) do |scope_hash, scope_item|

--- a/test/active_record/cases/test_uniqueness_validator.rb
+++ b/test/active_record/cases/test_uniqueness_validator.rb
@@ -46,5 +46,11 @@ class ActiveRecord::UniquenessValidatorTest < ClientSideValidations::ActiveRecor
     expected_hash = { :message => "has already been taken", :case_sensitive => true, :class => 'active_record_test_module/user2' }
     assert_equal expected_hash, UniquenessValidator.new(:attributes => [:name]).client_side_hash(@user, :name)
   end
+
+  def test_uniqueness_client_side_hash_with_allow_blank
+    expected_hash = { :message => "has already been taken", :case_sensitive => true, :allow_blank => true }
+    assert_equal expected_hash, UniquenessValidator.new(:attributes => [:name], :allow_blank => true).client_side_hash(@user, :name)
+  end
+
 end
 

--- a/test/mongo_mapper/cases/test_uniqueness_validator.rb
+++ b/test/mongo_mapper/cases/test_uniqueness_validator.rb
@@ -3,7 +3,7 @@ require 'mongo_mapper/cases/test_base'
 class MongoMapper::UniqunessValidatorTest < ClientSideValidations::MongoMapperTestBase
 
   def test_uniqueness_client_side_hash
-    expected_hash = { :message => "has already been taken" }
+    expected_hash = { :message => "has already been taken", :case_sensitive => true }
     assert_equal expected_hash, UniquenessValidator.new(:attributes => [:name]).client_side_hash(@magazine, :age)
   end
 
@@ -12,7 +12,7 @@ class MongoMapper::UniqunessValidatorTest < ClientSideValidations::MongoMapperTe
     assert_equal expected_hash, UniquenessValidator.new(:attributes => [:name], :message => "is not available").client_side_hash(@magazine, :age)
   end
 
-  def test_uniqueness_client_side_hash
+  def test_uniqueness_client_side_hash_with_id
     @magazine.stubs(:new_record?).returns(false)
     @magazine.stubs(:id).returns(1)
     expected_hash = { :message => "has already been taken", :case_sensitive => true , :id => 1 }
@@ -44,6 +44,11 @@ class MongoMapper::UniqunessValidatorTest < ClientSideValidations::MongoMapperTe
     @magazine = MongoMapperTestModule::Magazine2.new
     expected_hash = { :message => "has already been taken", :case_sensitive => true, :class => 'mongo_mapper_test_module/magazine2' }
     assert_equal expected_hash, UniquenessValidator.new(:attributes => [:name]).client_side_hash(@magazine, :age)
+  end
+
+  def test_uniqueness_client_side_hash_with_custom_message
+    expected_hash = { :message => "has already been taken", :case_sensitive => true, :allow_blank => true }
+    assert_equal expected_hash, UniquenessValidator.new(:attributes => [:name], :allow_blank => true).client_side_hash(@magazine, :age)
   end
 
 end

--- a/test/mongoid/cases/test_uniqueness_validator.rb
+++ b/test/mongoid/cases/test_uniqueness_validator.rb
@@ -12,7 +12,7 @@ class Mongoid::UniqunessValidatorTest < ClientSideValidations::MongoidTestBase
     assert_equal expected_hash, UniquenessValidator.new(:attributes => [:name], :message => "is not available").client_side_hash(@book, :age)
   end
 
-  def test_uniqueness_client_side_hash
+  def test_uniqueness_client_side_hash_with_id
     @book.stubs(:new_record?).returns(false)
     @book.stubs(:id).returns(1)
     expected_hash = { :message => "is already taken", :id => 1 }
@@ -44,6 +44,11 @@ class Mongoid::UniqunessValidatorTest < ClientSideValidations::MongoidTestBase
     @book = MongoidTestModule::Book2.new
     expected_hash = { :message => "is already taken", :class => 'mongoid_test_module/book2' }
     assert_equal expected_hash, UniquenessValidator.new(:attributes => [:name]).client_side_hash(@book, :age)
+  end
+
+  def test_uniqueness_client_side_hash_with_allow_blank
+    expected_hash = { :message => "is already taken", :allow_blank => true }
+    assert_equal expected_hash, UniquenessValidator.new(:attributes => [:name], :allow_blank => true).client_side_hash(@book, :age)
   end
 end
 


### PR DESCRIPTION
In regard to Issue #388.

Found that although the JS component of CSV looks for the allow_blank option for validates_uniqueness, it wasn't being passed through from server side.

These changes cover active_record, mongo_mappper and mongoid adapters.

Includes updated test suite.
