### PR TITLE
fix numericality js error 'Unexpected token >' when input blank

### DIFF
--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -173,7 +173,7 @@ var clientSideValidations = {
           equal_to: '==', less_than: '<', less_than_or_equal_to: '<=' }
 
         for (var check in CHECKS) {
-          if (options[check] != undefined && !(new Function("return " + element.val() + CHECKS[check] + options[check])())) {
+          if (options[check] != undefined && !(new Function("return " + parseInt(element.val()) + CHECKS[check] + options[check])())) {
             return options.messages[check];
           }
         }


### PR DESCRIPTION
Hi Brian,

I can see that this issue has been adressed in master (in coffeescript version).

just a heads-up for people using the gem version, this is a hard-to-track error,

``` ruby
validates :percentage,
  numericality: {
    greater_than: 0
  }
```

if input that checks for numericality is blank, js fail with syntax-error 'Unexpected token >' ,  this is because `element.val()` returns empty string.

one can only see a slight js error in console before form gets submitted.

Thanks to this bug, I learned a delightful snippet when working with client_side_validations form:

``` coffeescript

$(document).on 'submit', 'form', (event) ->
  event.preventDefault()
```
