### PR TITLE
do not validate 'decorative' inputs

### DIFF
--- a/coffeescript/rails.validations.coffee
+++ b/coffeescript/rails.validations.coffee
@@ -154,7 +154,7 @@ window.ClientSideValidations.enablers =
     form   = input.form
     $form  = $(form)
 
-    $input.filter(':enabled:not(:radio):not([id$=_confirmation]):visible')
+    $input.filter(':enabled:not(:radio):not([id$=_confirmation]):visible[name]')
       .each ->
         $(@).attr('data-validate', true)
       .on(event, binding) for event, binding of {

--- a/test/javascript/public/test/form_builders/validateForm.js
+++ b/test/javascript/public/test/form_builders/validateForm.js
@@ -136,3 +136,15 @@ asyncTest('Disabled inputs do not stop form submission', 1, function() {
     ok($('iframe').contents().find('p:contains("Form submitted")')[0]);
   }, 60);
 });
+
+asyncTest('Decorative (without name) inputs aren\'t validated', 1, function() {
+  var form = $('form#new_user'), input = form.find('input#user_name');
+  input.val('Test');
+  form.append($('<input />', {type: 'text'})).validate();
+
+  form.trigger('submit');
+  setTimeout(function() {
+    start();
+    ok($('iframe').contents().find('p:contains("Form submitted")')[0]);
+  }, 60);
+});

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -229,7 +229,7 @@
       };
       for (event in _ref) {
         binding = _ref[event];
-        $input.filter(':enabled:not(:radio):not([id$=_confirmation]):visible').each(function() {
+        $input.filter(':enabled:not(:radio):not([id$=_confirmation]):visible[name]').each(function() {
           return $(this).attr('data-validate', true);
         }).on(event, binding);
       }


### PR DESCRIPTION
Hi I faced with problems when my form has some decorative inputs (without names).

When validate, your script implies that input should have name.

So I write patch, that filters such inputs from validation (and also write test).

Don't know in which branch send this patch, so I send in master, I can resend in 3-2-stable, if needed.
