### PR TITLE
Fix for forms using :index option

### DIFF
--- a/lib/client_side_validations/action_view/form_builder.rb
+++ b/lib/client_side_validations/action_view/form_builder.rb
@@ -93,7 +93,8 @@ module ClientSideValidations::ActionView::Helpers
 
     def build_validation_options(method, options = {})
       if @options[:validate]
-        name = options[:name] || "#{@object_name}[#{method}]"
+        index = @default_options[:index].present? ? "[#{@default_options[:index]}]" : ''
+        name = options[:name] || "#{@object_name}#{index}[#{method}]"
         child_index = @options[:child_index] ? "(\\d+|#{Regexp.escape(@options[:child_index])})" : "\\d+"
         name = name.to_s.gsub(/_attributes\]\[#{child_index}\]/, '_attributes][]')
         name = "#{name}#{options[:multiple] ? "[]" : nil}"


### PR DESCRIPTION
If you use something like

``` ruby
objects.all do |object|
  f.fields_for object, :index => object.id do |fld|
end
```

validators names are generated wrongly because they ignore index argument (lib/client_side_validations/action_view/form_builder.rb #build_validation_options) and they are not found when field is validated.

This patch checks whether index is present in @default_options (see docs for FormBuilder http://apidock.com/rails/v3.2.8/ActionView/Helpers/FormBuilder/new/class) and if it is, it's injected between @object_name and method.
