### PR TITLE
Ensure that priority_zones isn't redefined to nil

### DIFF
--- a/lib/client_side_validations/action_view/form_builder.rb
+++ b/lib/client_side_validations/action_view/form_builder.rb
@@ -86,7 +86,7 @@ module ClientSideValidations::ActionView::Helpers
     def time_zone_select_with_client_side_validations(method, priority_zones = nil, options = {}, html_options = {})
       build_validation_options(method, html_options.merge(:name => options[:name]))
       html_options.delete(:validate)
-      time_zone_select_without_client_side_validations(method, priority_zones = nil, options, html_options)
+      time_zone_select_without_client_side_validations(method, priority_zones, options, html_options)
     end
 
   private


### PR DESCRIPTION
As previously fixed on 3.1 by @leemhenson in commit 0d7090c6c7337a377bc6ffc1c96938a3535523c3
