### PR TITLE
Make configurable which inputs validateForm will validate

### DIFF
--- a/coffeescript/rails.validations.coffee
+++ b/coffeescript/rails.validations.coffee
@@ -38,7 +38,7 @@ validateForm = (form, validators) ->
   form.trigger('form:validate:before.ClientSideValidations')
 
   valid = true
-  form.find(':input:enabled:visible[data-validate]').each ->
+  form.find(ClientSideValidations.selectors.validate_inputs).each ->
     valid = false unless $(@).isValid(validators)
     # we don't want the loop to break out by mistake
     true
@@ -108,6 +108,7 @@ if window.ClientSideValidations.forms == undefined
 
 window.ClientSideValidations.selectors =
   inputs: ':input:not(button):not([type="submit"])[name]:visible:enabled'
+  validate_inputs: ':input:enabled:visible[data-validate]'
   forms:  'form[data-validate]'
 
 window.ClientSideValidations.reset = (form) ->

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -48,7 +48,7 @@
     var valid;
     form.trigger('form:validate:before.ClientSideValidations');
     valid = true;
-    form.find(':input:enabled:visible[data-validate]').each(function() {
+    form.find(ClientSideValidations.selectors.validate_inputs).each(function() {
       if (!$(this).isValid(validators)) {
         valid = false;
       }
@@ -128,6 +128,7 @@
 
   window.ClientSideValidations.selectors = {
     inputs: ':input:not(button):not([type="submit"])[name]:visible:enabled',
+    validate_inputs: ':input:enabled:visible[data-validate]',
     forms: 'form[data-validate]'
   };
 


### PR DESCRIPTION
I needed validation of disabled form fields which is impossible since #177 was closed. This lets me enable it via setting

``` coffeescript
ClientSideValidations.selectors.inputs = ':input:not(button):not([type="submit"])[name]:visible'
ClientSideValidations.selectors.validate_inputs = ':input:visible[data-validate]'
```
