### PR TITLE
jQuery 1.9 compatibility, use .prop('checked')

### DIFF
--- a/coffeescript/rails.validations.coffee
+++ b/coffeescript/rails.validations.coffee
@@ -207,7 +207,7 @@ window.ClientSideValidations.validators =
       acceptance: (element, options) ->
         switch element.attr('type')
           when 'checkbox'
-            unless element.attr('checked')
+            unless element.prop('checked')
               return options.message
           when 'text'
             if element.val() != (options.accept?.toString() || '1')

--- a/test/javascript/public/test/validateElement.js
+++ b/test/javascript/public/test/validateElement.js
@@ -100,7 +100,7 @@ test('Validate when checkbox is clicked', function() {
   var form = $('form#new_user'), input = form.find('input#user_agree');
   var label = $('label[for="user_agree"]');
 
-  input.attr('checked', false)
+  input.prop('checked', false)
   input.trigger('click');
   ok(input.parent().hasClass('field_with_errors'));
   ok(label.parent().hasClass('field_with_errors'));

--- a/test/javascript/public/test/validators/acceptance.js
+++ b/test/javascript/public/test/validators/acceptance.js
@@ -3,7 +3,7 @@ module('Acceptance options');
 test('when checkbox and checked', function() {
   var element = $('<input type="checkbox" />');
   var options = { message: "failed validation" };
-  element.attr('checked', true)
+  element.prop('checked', true)
   equal(ClientSideValidations.validators.local.acceptance(element, options), undefined);
 });
 

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -284,7 +284,7 @@
         var _ref;
         switch (element.attr('type')) {
           case 'checkbox':
-            if (!element.attr('checked')) {
+            if (!element.prop('checked')) {
               return options.message;
             }
             break;


### PR DESCRIPTION
jQuery 1.9 uses .prop instead of .attr for checking the property.

http://jquery.com/upgrade-guide/1.9/
