### PR TITLE
Fixed disabling validators; fixed regressions

### DIFF
--- a/coffeescript/rails.validations.coffee
+++ b/coffeescript/rails.validations.coffee
@@ -399,6 +399,12 @@ window.ClientSideValidations.validators =
         }).status == 200
           return options.message
 
+window.ClientSideValidations.disableValidators = () ->
+  return if window.ClientSideValidations.disabled_validators == undefined
+  for validator, func of window.ClientSideValidations.validators.remote
+    unless window.ClientSideValidations.disabled_validators.indexOf(validator) == -1
+      delete window.ClientSideValidations.validators.remote[validator]
+
 window.ClientSideValidations.formBuilders =
     'ActionView::Helpers::FormBuilder':
       add: (element, settings, message) ->
@@ -451,4 +457,7 @@ window.ClientSideValidations.callbacks =
 # Main hook
 # If new forms are dynamically introduced into the DOM the .validate() method
 # must be invoked on that form
-$(-> $(ClientSideValidations.selectors.forms).validate())
+$(->
+  ClientSideValidations.disableValidators()
+  $(ClientSideValidations.selectors.forms).validate()
+)

--- a/lib/client_side_validations/action_view/form_helper.rb
+++ b/lib/client_side_validations/action_view/form_helper.rb
@@ -131,7 +131,7 @@ module ClientSideValidations::ActionView::Helpers
 
 
         content_tag(:script) do
-          "//<![CDATA[\nif(window.ClientSideValidations==undefined)window.ClientSideValidations={};window.ClientSideValidations.number_format=#{number_format.to_json};window.ClientSideValidations.patterns.numericality=#{patterns[:numericality]};if(window.ClientSideValidations.remote_validators_prefix==undefined)window.ClientSideValidations.remote_validators_prefix='#{(root_path||"").sub(/(\/)+$/,'')}';if(window.ClientSideValidations.forms==undefined)window.ClientSideValidations.forms={};window.ClientSideValidations.forms['#{var_name}'] = #{builder.client_side_form_settings(options, self).merge(:validators => 'validator_hash').to_json};\n//]]>".html_safe
+          %|//<![CDATA[\nif(window.ClientSideValidations===undefined)window.ClientSideValidations={};window.ClientSideValidations.disabled_validators=#{ClientSideValidations::Config.disabled_validators.to_json};window.ClientSideValidations.number_format=#{number_format.to_json};if(window.ClientSideValidations.patterns===undefined)window.ClientSideValidations.patterns = {};window.ClientSideValidations.patterns.numericality=#{patterns[:numericality]};if(window.ClientSideValidations.remote_validators_prefix===undefined)window.ClientSideValidations.remote_validators_prefix='#{(ClientSideValidations::Config.root_path||"").sub(/\/+\Z/,'')}';if(window.ClientSideValidations.forms===undefined)window.ClientSideValidations.forms={};window.ClientSideValidations.forms['#{var_name}'] = #{builder.client_side_form_settings(options, self).merge(:validators => 'validator_hash').to_json};\n//]]>|.html_safe
         end
       end
     end

--- a/lib/client_side_validations/config.rb
+++ b/lib/client_side_validations/config.rb
@@ -3,9 +3,11 @@ module ClientSideValidations
     class << self
       attr_accessor :disabled_validators
       attr_accessor :number_format_with_locale
+      attr_accessor :root_path
     end
 
     self.disabled_validators = []
     self.number_format_with_locale = false
+    self.root_path = nil
   end
 end

--- a/test/action_view/cases/helper.rb
+++ b/test/action_view/cases/helper.rb
@@ -137,9 +137,10 @@ module ActionViewTestSetup
   end
 
   def build_script_tag(html, id, validators)
-    number_format = {:separator=>".", :delimiter=>","}
+    number_format = {:separator => '.', :delimiter => ','}
     patterns = {:numericality=>"/^(-|\\+)?(?:\\d+|\\d{1,3}(?:\\#{number_format[:delimiter]}\\d{3})+)(?:\\#{number_format[:separator]}\\d*)?$/"}
-    (html || "") + %Q{<script>//<![CDATA[\nif(window.ClientSideValidations==undefined)window.ClientSideValidations={};window.ClientSideValidations.number_format=#{number_format.to_json};window.ClientSideValidations.patterns.numericality=#{patterns[:numericality]};if(window.ClientSideValidations.remote_validators_prefix==undefined)window.ClientSideValidations.remote_validators_prefix='';if(window.ClientSideValidations.forms==undefined)window.ClientSideValidations.forms={};window.ClientSideValidations.forms['#{id}'] = #{client_side_form_settings_helper.merge(:validators => validators).to_json};\n//]]></script>}
+    (html || '') + %|<script>//<![CDATA[\nif(window.ClientSideValidations===undefined)window.ClientSideValidations={};window.ClientSideValidations.disabled_validators=#{ClientSideValidations::Config.disabled_validators.to_json};window.ClientSideValidations.number_format=#{number_format.to_json};if(window.ClientSideValidations.patterns===undefined)window.ClientSideValidations.patterns = {};window.ClientSideValidations.patterns.numericality=#{patterns[:numericality]};if(window.ClientSideValidations.remote_validators_prefix===undefined)window.ClientSideValidations.remote_validators_prefix='#{(ClientSideValidations::Config.root_path||"").sub(/\/+\Z/,'')}';if(window.ClientSideValidations.forms===undefined)window.ClientSideValidations.forms={};window.ClientSideValidations.forms['#{id}'] = #{client_side_form_settings_helper.merge(:validators => validators).to_json};\n//]]></script>|
+
   end
 
   protected

--- a/test/javascript/public/test/disableValidators.js
+++ b/test/javascript/public/test/disableValidators.js
@@ -1,0 +1,32 @@
+module('Disabling validators', {
+  setup: function() {
+    ClientSideValidations.validators = {
+      local: {
+        test: function(){},
+        test2: function(){}
+      },
+      remote: {
+        test: function(){},
+        test3: function(){}
+      }
+    }
+  }
+});
+
+test('when some validators are disabled', function() {
+  var keys = []; for(var k in ClientSideValidations.validators.remote) keys.push(k);
+  deepEqual(keys, ['test', 'test3']);
+  ClientSideValidations.disabled_validators = ['test'];
+  ClientSideValidations.disableValidators();
+  keys = []; for(var k in ClientSideValidations.validators.remote) keys.push(k);
+  deepEqual(keys, ['test3']);
+});
+
+test('when none of validators are disabled', function() {
+  var keys = []; for(var k in ClientSideValidations.validators.remote) keys.push(k);
+  deepEqual(keys, ['test', 'test3']);
+  ClientSideValidations.disabled_validators = [];
+  ClientSideValidations.disableValidators();
+  keys = []; for(var k in ClientSideValidations.validators.remote) keys.push(k);
+  deepEqual(keys, ['test', 'test3']);
+});

--- a/test/javascript/views/index.erb
+++ b/test/javascript/views/index.erb
@@ -3,6 +3,7 @@
 <%= test_base %>
 <%= script_tag 'validateElement' %>
 <%= test :validators, :form_builders, :callbacks %>
+<%= script_tag 'disableValidators' %>
 
 <h1 id="qunit-header"><%= @title %></h1>
 

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -548,6 +548,25 @@
     }
   };
 
+  window.ClientSideValidations.disableValidators = function() {
+    var func, validator, _ref, _results;
+    if (window.ClientSideValidations.disabled_validators === void 0) {
+      return;
+    }
+    _ref = window.ClientSideValidations.validators.remote;
+    _results = [];
+    for (validator in _ref) {
+      func = _ref[validator];
+      console.log(window.ClientSideValidations.disabled_validators);
+      if (window.ClientSideValidations.disabled_validators.indexOf(validator) !== -1) {
+        _results.push(delete window.ClientSideValidations.validators.remote[validator]);
+      } else {
+        _results.push(void 0);
+      }
+    }
+    return _results;
+  };
+
   window.ClientSideValidations.formBuilders = {
     'ActionView::Helpers::FormBuilder': {
       add: function(element, settings, message) {
@@ -610,6 +629,7 @@
   };
 
   $(function() {
+    ClientSideValidations.disableValidators();
     return $(ClientSideValidations.selectors.forms).validate();
   });
 


### PR DESCRIPTION
Now we remove disabled validators from `validators.remote` on client so we won't make requests to them. Fixes #468

Also fixes error when js is inserted after form and we don't have `ClientSideValidations.patterns`, and moves `root_path` detection to config since it fails to work with paths with params produced by default_url_options.

In fact it can be set from root_path, but that'd require more thorough sanitisation. Maybe next time.
