### PR TITLE
Fix only_integer validation when locale delimiters are used.

### DIFF
--- a/coffeescript/rails.validations.coffee
+++ b/coffeescript/rails.validations.coffee
@@ -228,6 +228,8 @@ window.ClientSideValidations.validators =
           return if options.allow_blank == true and @presence(element, {message: options.messages.numericality})
           return options.messages.numericality
 
+        val = val.replace(new RegExp("\\#{ClientSideValidations.number_format.delimiter}",'g'),"").replace(new RegExp("\\#{ClientSideValidations.number_format.separator}",'g'),".")
+
         if options.only_integer and !/^[+-]?\d+$/.test(val)
           return options.messages.only_integer
 
@@ -248,7 +250,6 @@ window.ClientSideValidations.validators =
           else
             return
 
-          val = val.replace(new RegExp("\\#{ClientSideValidations.number_format.delimiter}",'g'),"").replace(new RegExp("\\#{ClientSideValidations.number_format.separator}",'g'),".")
           fn = new Function("return #{val} #{operator} #{check_value}")
           return options.messages[check] unless fn()
 

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -321,6 +321,7 @@
           }
           return options.messages.numericality;
         }
+        val = val.replace(new RegExp("\\" + ClientSideValidations.number_format.delimiter, 'g'), "").replace(new RegExp("\\" + ClientSideValidations.number_format.separator, 'g'), ".");
         if (options.only_integer && !/^[+-]?\d+$/.test(val)) {
           return options.messages.only_integer;
         }
@@ -344,7 +345,6 @@
           } else {
             return;
           }
-          val = val.replace(new RegExp("\\" + ClientSideValidations.number_format.delimiter, 'g'), "").replace(new RegExp("\\" + ClientSideValidations.number_format.separator, 'g'), ".");
           fn = new Function("return " + val + " " + operator + " " + check_value);
           if (!fn()) {
             return options.messages[check];
@@ -571,7 +571,7 @@
       add: function(element, settings, message) {
         var form, inputErrorField, label, labelErrorField;
         form = $(element[0].form);
-        if (element.data('valid') !== false && !(form.find("label.message[for='" + (element.attr('id')) + "']")[0] != null)) {
+        if (element.data('valid') !== false && (form.find("label.message[for='" + (element.attr('id')) + "']")[0] == null)) {
           inputErrorField = jQuery(settings.input_tag);
           labelErrorField = jQuery(settings.label_tag);
           label = form.find("label[for='" + (element.attr('id')) + "']:not(.message)");


### PR DESCRIPTION
If only_integer is set to true for a numericality validation, it can't take advantage of the localization settings added in #461. So for example, I cannot enter "1,000" for a numericality validation when only_integer is set to true (but that does validate when only_integer is set to false).

This fixes that so that integer validations can also be entered with the delimiter. It's also a very minuscule optimization, since the replacement regex is only done once on the number, instead of multiple times inside the loop.

All the numericality javascript tests seem to be commented out, so I wasn't quite sure about how to add a test case around this. Let me know if you want me to add one or have any questions.
