### PR TITLE
Fixes #498 and #499 (IE8 incompatibility)

### DIFF
--- a/coffeescript/rails.validations.coffee
+++ b/coffeescript/rails.validations.coffee
@@ -407,7 +407,7 @@ window.ClientSideValidations.remote_validators_url_for = (validator) ->
 window.ClientSideValidations.disableValidators = () ->
   return if window.ClientSideValidations.disabled_validators == undefined
   for validator, func of window.ClientSideValidations.validators.remote
-    unless window.ClientSideValidations.disabled_validators.indexOf(validator) == -1
+    if validator in window.ClientSideValidations.disabled_validators
       delete window.ClientSideValidations.validators.remote[validator]
 
 window.ClientSideValidations.formBuilders =

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -562,7 +562,7 @@
     _results = [];
     for (validator in _ref) {
       func = _ref[validator];
-      if (window.ClientSideValidations.disabled_validators.indexOf(validator) !== -1) {
+      if (__indexOf.call(window.ClientSideValidations.disabled_validators, validator) >= 0) {
         _results.push(delete window.ClientSideValidations.validators.remote[validator]);
       } else {
         _results.push(void 0);


### PR DESCRIPTION
Fixes #498 and #499 (IE8 incompatibility).

Changes a call to `Array.indexOf` to use coffeescript's `if x in Array` instead, which is automatically shimmed for old JS support.
