### PR TITLE
Added ability to override class name for uniqueness validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ that `<script>` tag elsewhere you can do this by passing a name to
 <%= form_for @user, :validate => :user_validators do |f| %>
 ```
 
-The `<script`> tag is added to `content_for()` with the name you passed, 
+The `<script`> tag is added to `content_for()` with the name you passed,
 so you can simply render that anywhere you like:
 
 ```erb
@@ -163,6 +163,37 @@ You can even turn them off per fieldset:
 ```erb
 <%= f.fields_for :profile, :validate => false do |p| %>
   ...
+```
+
+## Wrapper objects and remote validations ##
+
+For example, we have a wrapper class for the User model, UserForm, and it uses remote uniqueness validation for the `email` field.
+
+```ruby
+class UserForm
+  include ActiveRecord::Validations
+  attr_accessor :email
+  validates_uniqueness_of :email
+end
+...
+<% form_for(UserForm.new) do %>
+...
+```
+
+However, this won't work since middleware will try to perform validation against UserForm, and it's not persisted.
+
+This is solved by passing `client_validations` options hash to the validator, that currently supports one key — `:class`, and setting correct name to the form object:
+
+```ruby
+class UserForm
+  include ActiveRecord::Validations
+  attr_accessor :email
+  validates_uniqueness_of :email, :client_validations => { :class =>
+  'User' }
+end
+...
+<% form_for(UserForm.new, :as => :user) do %>
+...
 ```
 
 ## Understanding the embedded `<script>` tag ##
@@ -407,7 +438,7 @@ You can reset the current state of the validations, clear all error messages, an
 
 ```js
 $(form).resetClientSideValidations();
-```  
+```
 
 ## Callbacks ##
 
@@ -440,7 +471,7 @@ window.ClientSideValidations.callbacks.element.fail = function(element, message,
 }
 
 window.ClientSideValidations.callbacks.element.pass = function(element, callback) {
-  // Take note how we're passing the callback to the hide() 
+  // Take note how we're passing the callback to the hide()
   // method so it is run after the animation is complete.
   element.parent().find('.message').hide('slide', {direction: "left"}, 500, callback);
 }
@@ -471,7 +502,7 @@ ClientSideValidations::Config.disabled_validators = [:uniqueness]
 
 This will completely disable the uniqueness validator. The `FormBuilder`
 will automatically skip building validators that are disabled.
- 
+
 ## Authors ##
 
 [Brian Cardarella](http://twitter.com/bcardarella)
@@ -484,7 +515,7 @@ This gem follows [Semantic Versioning](http://semver.org)
 
 Major and minor version numbers will follow `Rails`'s major and
 minor version numbers. For example,
-`client_side_validations-3.2.0` will be compatible up to 
+`client_side_validations-3.2.0` will be compatible up to
 `~> rails-3.2.0`
 
 We will maintain compatibility with one minor version back. So the 3.2.0 version of

--- a/lib/client_side_validations/active_record/uniqueness.rb
+++ b/lib/client_side_validations/active_record/uniqueness.rb
@@ -6,14 +6,17 @@ module ClientSideValidations::ActiveRecord
       hash[:case_sensitive] = options[:case_sensitive]
       hash[:id]             = model.id unless model.new_record?
       hash[:allow_blank]    = true if options[:allow_blank]
+
+      if options.key?(:client_validations) && options[:client_validations].key?(:class)
+        hash[:class] = options[:client_validations][:class].underscore
+      elsif model.class.name.demodulize != model.class.name
+        hash[:class] = model.class.name.underscore
+      end
+
       if options.key?(:scope) && options[:scope].present?
         hash[:scope] = Array.wrap(options[:scope]).inject({}) do |scope_hash, scope_item|
           scope_hash.merge!(scope_item => model.send(scope_item))
         end
-      end
-
-      unless model.class.name.demodulize == model.class.name
-        hash[:class] = model.class.name.underscore
       end
 
       hash

--- a/test/active_record/cases/test_uniqueness_validator.rb
+++ b/test/active_record/cases/test_uniqueness_validator.rb
@@ -51,5 +51,11 @@ class ActiveRecord::UniquenessValidatorTest < ClientSideValidations::ActiveRecor
     expected_hash = { :message => "has already been taken", :case_sensitive => true, :class => 'active_record_test_module/user2' }
     assert_equal expected_hash, UniquenessValidator.new(:attributes => [:name]).client_side_hash(@user, :name)
   end
+
+  def test_uniqueness_client_side_hash_with_class_from_options
+    @user = UserForm.new
+    expected_hash = { :message => "has already been taken", :case_sensitive => true, :class => 'user' }
+    assert_equal expected_hash, UniquenessValidator.new(:attributes => [:name], :client_validations => { :class => 'User' } ).client_side_hash(@user, :name)
+  end
 end
 

--- a/test/active_record/models/user.rb
+++ b/test/active_record/models/user.rb
@@ -12,3 +12,19 @@ class Thaumaturgist < Conjurer; end
 module ActiveRecordTestModule
   class User2 < User; end
 end
+
+class UserForm
+  include ActiveRecord::Validations
+
+  attr_accessor :name
+
+  validates_uniqueness_of :name, :client_validations => { :class => User }
+
+  def self.i18n_scope
+    :activerecord
+  end
+
+  def new_record?
+    true
+  end
+end


### PR DESCRIPTION
Closes #519

Added `:client_validations` option to the `validate_uniqueness_of`,
where one can specify the real class name for the remote validation.

For example, we have a wrapper class for the User model, UserForm, and
it uses remote uniqueness validation for the email field.

```
class UserForm
  include ActiveRecord::Validations
  attr_accessor :email
  validates_uniqueness_of :email
end
```

However, this won't work since middleware will try to perform validation
against UserForm, and it's not persisted.

Now one can state which class should be used for validation:

```
class UserForm
  include ActiveRecord::Validations
  attr_accessor :email
  validates_uniqueness_of :email, :client_validations => { :class =>
  User }
end
```
