### PR TITLE
Fix remote uniqueness validation because of double slash

### DIFF
--- a/coffeescript/rails.validations.coffee
+++ b/coffeescript/rails.validations.coffee
@@ -402,7 +402,7 @@ window.ClientSideValidations.validators =
 
 window.ClientSideValidations.remote_validators_url_for = (validator) ->
   if ClientSideValidations.remote_validators_prefix?
-    "//#{window.location.host}/#{ClientSideValidations.remote_validators_prefix}/validators/#{validator}"
+    "//#{window.location.host}/#{ClientSideValidations.remote_validators_prefix}validators/#{validator}"
   else
     "//#{window.location.host}/validators/#{validator}"
 


### PR DESCRIPTION
This fixes an issue I had:

```
Started GET "/uniqueness?case_sensitive=true&user%5Bemail%5D=beat.besmer%40gmail.com&_=1367362834432" for 127.0.0.1 at 2013-05-01 01:00:45 +0200

ActionController::RoutingError (No route matches [GET] "/uniqueness"):
```

The problem was that the url would contain two slashes `//` (JS Console)

```
JSCONSOLE> ClientSideValidations.remote_validators_url_for('uniqueness')
"//localhost:3000//validators/uniqueness"
```

Also see http://stackoverflow.com/questions/15903572/actioncontrollerroutingerror-no-route-matches-get-uniqueness
