### PR TITLE
exports javascript validateElement method

### DIFF
--- a/coffeescript/rails.validations.coffee
+++ b/coffeescript/rails.validations.coffee
@@ -102,6 +102,8 @@ validateElement = (element, validators) ->
 
   afterValidate()
 
+window.ClientSideValidations.validateElement = validateElement
+
 if window.ClientSideValidations == undefined
   window.ClientSideValidations = {}
 

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -125,6 +125,8 @@
     }
     return afterValidate();
   };
+  
+  window.ClientSideValidations.validateElement = validateElement
 
   if (window.ClientSideValidations === void 0) {
     window.ClientSideValidations = {};


### PR DESCRIPTION
Then, we can define `validateAttribute` method, used in the [x-editable validate](http://vitalets.github.io/x-editable/docs.html) and more.

```coffeescript
ClientSideValidations = @ClientSideValidations
ClientSideValidations.RecordValidators ||= {}

ClientSideValidations.validateAttribute = (resourceName, attribute, elementOrString, options={}) ->
  validatorsHash = options.validatorsHash || ClientSideValidations.RecordValidators[resourceName]?[attribute]
  return unless validatorsHash?

  if typeof(elementOrString) == 'string'
    element = $("<input type='hidden'/>").val(elementOrString).attr
      id: "#{resourceName}_#{attribute}"
      name: "#{resourceName}[#{attribute}]"
  else
    element = elementOrString
  
  element.on 'element:validate:before.ClientSideValidations', (e)->
    options.beforeFunc?()

  element.on 'element:validate:pass.ClientSideValidations', (e)->
    options.passFunc?()

  element.on 'element:validate:fail.ClientSideValidations', (e, message)->
    options.failFunc?(message)

  element.on 'element:validate:after.ClientSideValidations', (e)->
    options.afterFunc?()

  ClientSideValidations.validateElement(element, validatorsHash)
```