### PR TITLE
Fixes fields_for with deeply nested has_many associations

### DIFF
--- a/coffeescript/rails.validations.coffee
+++ b/coffeescript/rails.validations.coffee
@@ -35,10 +35,7 @@ $.fn.isValid = (validators) ->
     validateElement(obj, validatorsFor(@[0].name, validators))
 
 validatorsFor = (name, validators) ->
-  if captures = name.match /\[(\w+_attributes)\].*\[(\w+)\]$/
-    for validator_name, validator of validators
-      if validator_name.match "\\[#{captures[1]}\\].*\\[\\]\\[#{captures[2]}\\]$"
-        name = name.replace /\[[\da-z_]+\]\[(\w+)\]$/g, "[][$1]"
+  name = name.replace /\[((?:new_)?\d+|[0-9a-f]{24})\]/g, "[]"
   validators[name] || {}
 
 validateForm = (form, validators) ->

--- a/test/javascript/public/test/validateElement.js
+++ b/test/javascript/public/test/validateElement.js
@@ -10,6 +10,7 @@ module('Validate Element', {
         'user[agree]':{"acceptance": [{"message": "must be accepted"}]},
         'user[email]':{"uniqueness":[{"message": "must be unique"}],"presence":[{"message": "must be present"}]},
         'user[info_attributes][eye_color]':{"presence":[{"message": "must be present"}]},
+        'user[info_attributes][][hair_attributes][][color]':{"presence":[{"message": "must be present"}]},
         'user[phone_numbers_attributes][][number]':{"presence":[{"message": "must be present"}]},
         'user[phone_numbers_attributes][country_code][][code]':{"presence":[{"message": "must be present"}]},
         'user[phone_numbers_attributes][deeply][nested][][attribute]':{"presence":[{"message": "must be present"}]}
@@ -101,6 +102,12 @@ module('Validate Element', {
           name: 'user[info_attributes][eye_color]',
           id: 'user_info_attributes_eye_color',
           type: 'text'
+        }))
+        .append($('<label for="user_info_attributes_200_hair_attributes_5154ce728c06dedad4000001_color">Deeply nested hair color</label>'))
+        .append($('<input />', {
+          name: 'user[info_attributes][200][hair_attributes][5154ce728c06dedad4000001][color]',
+          id: 'user_info_attributes_200_hair_attributes_5154ce728c06dedad4000001_color',
+          type: 'text'
         }));
 
     $('form#new_user').validate();
@@ -176,6 +183,12 @@ test('Validate nested attributes', function() {
 
   input = form.find('input#user_phone_numbers_attributes_deeply_nested_5154ce728c06dedad4000001_attribute');
   label = $('label[for="user_phone_numbers_attributes_deeply_nested_5154ce728c06dedad4000001_attribute"]');
+  input.trigger('focusout');
+  ok(input.parent().hasClass('field_with_errors'));
+  ok(label.parent().hasClass('field_with_errors'));
+
+  input = form.find('input#user_info_attributes_200_hair_attributes_5154ce728c06dedad4000001_color');
+  label = $('label[for="user_info_attributes_200_hair_attributes_5154ce728c06dedad4000001_color"]');
   input.trigger('focusout');
   ok(input.parent().hasClass('field_with_errors'));
   ok(label.parent().hasClass('field_with_errors'));

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -44,15 +44,7 @@
   };
 
   validatorsFor = function(name, validators) {
-    var captures, validator, validator_name;
-    if (captures = name.match(/\[(\w+_attributes)\].*\[(\w+)\]$/)) {
-      for (validator_name in validators) {
-        validator = validators[validator_name];
-        if (validator_name.match("\\[" + captures[1] + "\\].*\\[\\]\\[" + captures[2] + "\\]$")) {
-          name = name.replace(/\[[\da-z_]+\]\[(\w+)\]$/g, "[][$1]");
-        }
-      }
-    }
+    name = name.replace(/\[((?:new_)?\d+|[0-9a-f]{24})\]/g, "[]");
     return validators[name] || {};
   };
 


### PR DESCRIPTION
This is my proposition to fix the remaining issues of #516.

This code is not 100% perfect. If you would have an attribute name build up with exactly 24 characters containing only [0-9a-f] the code would not recognize it as an attribute name but would think it is an id for the nested attributes array. The same goes for when you would have attributes named new_\d.

I'd be glad to have the discussion here if this could/should be enhanced. I don't think we can have a solution that would be 100% correct. Let's not think about switching to something like Backbone.js for now but stick with what there is now and how we can fix it.
