### PR TITLE
String and Array types on ActiveModel conditionals

### DIFF
--- a/lib/client_side_validations/active_model.rb
+++ b/lib/client_side_validations/active_model.rb
@@ -86,11 +86,15 @@ module ClientSideValidations::ActiveModel
       result
     end
 
-    def run_conditional(method_name_value_or_proc)
-      if method_name_value_or_proc.respond_to?(:call)
-        method_name_value_or_proc.call(self)
+    def run_conditional(conditional)
+      if conditional.is_a?(String)
+        self.instance_eval(conditional)
+      elsif conditional.respond_to?(:all?)
+        conditional.all?{ |object| run_conditional(object) }
+      elsif conditional.respond_to?(:call)
+        conditional.call(self)
       else
-        self.send(method_name_value_or_proc)
+        self.send(conditional)
       end
     end
 

--- a/test/active_model/cases/test_validations.rb
+++ b/test/active_model/cases/test_validations.rb
@@ -201,6 +201,37 @@ class ActiveModel::ValidationsTest < ClientSideValidations::ActiveModelTestBase
     assert_equal expected_hash, person.client_side_validation_hash(true)
   end
 
+  def test_conditionals_of_array_and_string
+    person = new_person do |p|
+      p.validates :first_name, :presence => { :if => [:can_validate?, 'can_validate? == true'] }
+      p.validates :last_name,  :presence => { :unless => [:cannot_validate?, 'cannot_validate? == true'] }
+
+      p.class_eval do
+        def can_validate?
+          true
+        end
+
+        def cannot_validate?
+          false
+        end
+      end
+    end
+
+    expected_hash = {
+      :first_name => {
+        :presence => [{
+          :message => "can't be blank"
+        }]
+      },
+      :last_name => {
+        :presence => [{
+          :message => "can't be blank"
+        }]
+      }
+    }
+    assert_equal expected_hash, person.client_side_validation_hash(true)
+  end
+
   def test_conditionals_forcing_individual_attributes_on
     person = new_person do |p|
       p.validates :first_name, :presence => { :if => :can_validate? }, :length => { :is => 5, :if => :can_validate? }


### PR DESCRIPTION
This PR updates the `#run_conditional` method so that String and Array types are supported, as they are in ActiveModel. For example, you can do:

``` ruby
validates_presence_of :foobar, :if => 
    [:should_validate_things?, '@things_to_validate.include?("foobar)']
```

I realize this project is no longer being maintained, so I thought I'd just leave this here in case anyone finds it useful.
