### PR TITLE
invoke initialize_without_client_side_validations without block

### DIFF
--- a/lib/client_side_validations/action_view/form_builder.rb
+++ b/lib/client_side_validations/action_view/form_builder.rb
@@ -42,8 +42,8 @@ module ClientSideValidations::ActionView::Helpers
       nil
     end
 
-    def initialize_with_client_side_validations(object_name, object, template, options, proc=nil)
-      initialize_without_client_side_validations(object_name, object, template, options, proc)
+    def initialize_with_client_side_validations(object_name, object, template, options)
+      initialize_without_client_side_validations(object_name, object, template, options)
       @options[:validators] = { object => {} }
     end
 


### PR DESCRIPTION
Because Rails 4.1 has deprecated the block argument of the method `FormBuilder.initialize`, invoking the `initialize_without_client_side_validations` with **5** arguments will result in an `ArgumentError: wrong number of arguments (5 for 4)`, in the source codes of Rails 4.1:
```ruby
     def initialize(object_name, object, template, options)
        @nested_child_index = {}
        @object_name, @object, @template, @options = object_name, object, template, options
        @default_options = @options ? @options.slice(:index, :namespace) : {}
        if @object_name.to_s.match(/\[\]$/)
          if object ||= @template.instance_variable_get("@#{Regexp.last_match.pre_match}") and object.respond_to?(:to_param)
            @auto_index = object.to_param
          else
            raise ArgumentError, "object[] naming but object param and @object var don't exist or don't respond to to_param: #{object.inspect}"
          end
        end
        @multipart = nil
        @index = options[:index] || options[:child_index]
      end
```

and in the Rails 4.0, the block argument is compatible, see:
```ruby
# File actionpack/lib/action_view/helpers/form_helper.rb, line 1240
      def initialize(object_name, object, template, options, block=nil)
        if block
          ActiveSupport::Deprecation.warn "Giving a block to FormBuilder is deprecated and has no effect anymore."
        end

        @nested_child_index = {}
        @object_name, @object, @template, @options = object_name, object, template, options
        @default_options = @options ? @options.slice(:index, :namespace) : {}
        # something else
      end
```

In this PR, I clear the deprecated block argument to make the gem work with Rails 4.1.