### PR TITLE
Make ClientSideValidations::Config.root_path to work in middleware

### DIFF
--- a/lib/client_side_validations/middleware.rb
+++ b/lib/client_side_validations/middleware.rb
@@ -11,7 +11,11 @@ module ClientSideValidations
       end
 
       def call(env)
-        if matches = /\A\/validators\/(\w+)\z/.match(env['PATH_INFO'])
+        path = "/validators/"
+        if ClientSideValidations::Config.root_path
+          path = "/#{ClientSideValidations::Config.root_path}#{path}"
+        end
+        if matches = Regexp.new("\\A#{path}(\\w+)\\z").match(env['PATH_INFO'])
           process_request(matches.captures.first, env)
         else
           @app.call(env)


### PR DESCRIPTION
I found that you can change where the ajax requests for uniqueness tests are going by setting ClientSideValidations::Config.root_path But seems that the middleware route is always the same. This PR makes the middleware route to obey ClientSideValidations::Config.root_path.