### PR TITLE
fixed issue of removing error message

### DIFF
--- a/coffeescript/rails.validations.coffee
+++ b/coffeescript/rails.validations.coffee
@@ -441,7 +441,7 @@ window.ClientSideValidations.formBuilders =
       remove: (element, settings) ->
         form = $(element[0].form)
         errorFieldClass = jQuery(settings.input_tag).attr('class')
-        inputErrorField = element.closest(".#{errorFieldClass.replace(" ", ".")}")
+        inputErrorField = element.closest(".#{errorFieldClass.replace(/\ /g, ".")}")
         label = form.find("label[for='#{element.attr('id')}']:not(.message)")
         labelErrorField = label.closest(".#{errorFieldClass}")
 

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -608,7 +608,7 @@
         var errorFieldClass, form, inputErrorField, label, labelErrorField;
         form = $(element[0].form);
         errorFieldClass = jQuery(settings.input_tag).attr('class');
-        inputErrorField = element.closest("." + (errorFieldClass.replace(" ", ".")));
+        inputErrorField = element.closest("." + (errorFieldClass.replace(/\ /g, ".")));
         label = form.find("label[for='" + (element.attr('id')) + "']:not(.message)");
         labelErrorField = label.closest("." + errorFieldClass);
         if (inputErrorField[0]) {


### PR DESCRIPTION
if there are more than 2 classes for error field div class then if the error message is displayed it will not go if the user corrects the field

reproduction steps
1. goto client_side_validations.rb -> to the div with class 'field_with_errors' add two more classes let suppose 'form-group has-error' 
2. Now goto any form which is validated and generate error for any field and correct the error the error message will still be there. for example username should not be empty and you generated that error and correct it the message should go but if we have more that 2 classes for field_with_errors div then the previous strategy wont work this fixes that issue.


@tagliala sorry for too many pull requests This is the final one . I hope you are able to reproduce it.