### PR TITLE
Removing removal of whitespace from generated regex.

### DIFF
--- a/lib/client_side_validations/core_ext/regexp.rb
+++ b/lib/client_side_validations/core_ext/regexp.rb
@@ -8,7 +8,6 @@ class Regexp
       .sub(/\/[a-z]*$/ , '')
       .gsub(/\(\?#.+\)/ , '')
       .gsub(/\(\?-\w+:/ , '(')
-      .gsub(/\s/ , '')
     opts = []
     opts << 'i' if (self.options & Regexp::IGNORECASE) > 0
     opts << 'm' if (self.options & Regexp::MULTILINE) > 0

--- a/lib/client_side_validations/core_ext/regexp.rb
+++ b/lib/client_side_validations/core_ext/regexp.rb
@@ -8,6 +8,7 @@ class Regexp
       .sub(/\/[a-z]*$/ , '')
       .gsub(/\(\?#.+\)/ , '')
       .gsub(/\(\?-\w+:/ , '(')
+      .gsub(/\n/ , '\\n')
     opts = []
     opts << 'i' if (self.options & Regexp::IGNORECASE) > 0
     opts << 'm' if (self.options & Regexp::MULTILINE) > 0

--- a/lib/client_side_validations/core_ext/regexp.rb
+++ b/lib/client_side_validations/core_ext/regexp.rb
@@ -8,7 +8,8 @@ class Regexp
       .sub(/\/[a-z]*$/ , '')
       .gsub(/\(\?#.+\)/ , '')
       .gsub(/\(\?-\w+:/ , '(')
-      .gsub(/\n/ , '\\n')
+    str = (self.options & Regexp::EXTENDED) > 0 ? str.gsub(/\s/, '') : str.gsub(/[\t\r\n\f]/ , '')
+
     opts = []
     opts << 'i' if (self.options & Regexp::IGNORECASE) > 0
     opts << 'm' if (self.options & Regexp::MULTILINE) > 0

--- a/test/core_ext/cases/test_core_ext.rb
+++ b/test/core_ext/cases/test_core_ext.rb
@@ -59,7 +59,7 @@ class CoreExtTest < MiniTest::Test
   def test_multiline_regexp_as_json
     test_regexp = /
     /
-    expected_regexp = { source: '', options: '' }
+    expected_regexp = { source: '\n    ', options: '' }
     assert_equal expected_regexp, test_regexp.as_json
   end
 

--- a/test/core_ext/cases/test_core_ext.rb
+++ b/test/core_ext/cases/test_core_ext.rb
@@ -56,10 +56,13 @@ class CoreExtTest < MiniTest::Test
     assert_equal [0.5,5.5], (0.5..5.5).as_json
   end
 
-  def test_multiline_regexp_as_json
-    test_regexp = /
-    /
-    expected_regexp = { source: '\n    ', options: '' }
+  def test_whitespace_regexp_as_json
+    test_regexp = Regexp.new "tab: \u{9} | lf: \u{A} | cr: \u{D} | ff: \u{C}"
+    expected_regexp = { source: 'tab:  | lf:  | cr:  | ff: ', options: '' }
+    assert_equal expected_regexp, test_regexp.as_json
+
+    test_regexp = Regexp.new "tab: \u{9} | lf: \u{A} | cr: \u{D} | ff: \u{C}", Regexp::EXTENDED
+    expected_regexp = { source: 'tab:|lf:|cr:|ff:', options: '' }
     assert_equal expected_regexp, test_regexp.as_json
   end
 


### PR DESCRIPTION
This addresses the whitespace regex issue described in the response to #615.

I'm happy to develop tests for this issue also, but I first need to understand some of the logic in this this monkey patch. The first 3 replacements make sense, but after that I'm at a loss for why they need to be removed. It's also possible that the removal of white space was included for a reason, in which case some compromise will need to be found that doesn't kill valid regexes...