### PR TITLE
format validation: without means it's invalid if the match is found

### DIFF
--- a/coffeescript/rails.validations.coffee
+++ b/coffeescript/rails.validations.coffee
@@ -230,7 +230,7 @@ window.ClientSideValidations.validators =
           return message
 
         return options.message if options.with and !new RegExp(options.with.source, options.with.options).test(element.val())
-        return options.message if options.without and !new RegExp(options.without.source, options.without.options).test(element.val())
+        return options.message if options.without and new RegExp(options.without.source, options.without.options).test(element.val())
 
       numericality: (element, options) ->
         val = jQuery.trim(element.val())

--- a/test/javascript/public/test/validators/format.js
+++ b/test/javascript/public/test/validators/format.js
@@ -25,3 +25,15 @@ test('when not allowing blank', function() {
   var options = { 'message': "failed validation", 'with': /\d+/ };
   equal(ClientSideValidations.validators.local.format(element, options), "failed validation");
 });
+
+test('when using the without option and the Regex is matched', function() {
+  var element = $('<input type="text" value="Rock"/>');
+  var options = { 'message': "failed validation", 'without': /R/ };
+  equal(ClientSideValidations.validators.local.format(element, options), "failed validation");
+});
+
+test('when using the without option and the Regex is not matched', function() {
+  var element = $('<input type="text" value="Lock"/>');
+  var options = { 'message': "failed validation", 'without': /R/ };
+  equal(ClientSideValidations.validators.local.format(element, options), undefined);
+});

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -320,7 +320,7 @@
         if (options["with"] && !new RegExp(options["with"].source, options["with"].options).test(element.val())) {
           return options.message;
         }
-        if (options.without && !new RegExp(options.without.source, options.without.options).test(element.val())) {
+        if (options.without && new RegExp(options.without.source, options.without.options).test(element.val())) {
           return options.message;
         }
       },


### PR DESCRIPTION
    validates_format_of :field, without: /\ASomeRegex\z/

is working backwards--if the field matches the Regex, ClientSideValidations considers it valid.