### PR TITLE
Resolve issues #460, #615, #625 by using js_regex.

### DIFF
--- a/client_side_validations.gemspec
+++ b/client_side_validations.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '>= 4.0.0', '< 4.3.0'
   s.add_dependency 'jquery-rails', '>= 3.1.2', '< 5.0.0'
+  s.add_dependency 'js_regex', '~> 1.0'
 
   s.add_development_dependency 'appraisal', '~> 2.0'
   s.add_development_dependency 'coveralls', '~> 0.8.1'

--- a/lib/client_side_validations/core_ext/regexp.rb
+++ b/lib/client_side_validations/core_ext/regexp.rb
@@ -1,18 +1,8 @@
 class Regexp
+  require 'js_regex'
+
   def as_json(options = nil)
-    str = inspect
-      .sub('\\A' , '^')
-      .sub('\\Z' , '$')
-      .sub('\\z' , '$')
-      .sub(/^\// , '')
-      .sub(/\/[a-z]*$/ , '')
-      .gsub(/\(\?#.+\)/ , '')
-      .gsub(/\(\?-\w+:/ , '(')
-      .gsub(/\s/ , '')
-    opts = []
-    opts << 'i' if (self.options & Regexp::IGNORECASE) > 0
-    opts << 'm' if (self.options & Regexp::MULTILINE) > 0
-    { source: Regexp.new(str).source, options: opts.join }
+    JsRegex.new(self).to_h
   end
 
   def to_json(options = nil)

--- a/test/action_view/cases/helper.rb
+++ b/test/action_view/cases/helper.rb
@@ -29,6 +29,8 @@ module ActionViewTestSetup
       resources :comments
     end
 
+    resources :format_things
+
     root to: 'main#index'
   end
 
@@ -85,6 +87,7 @@ module ActionViewTestSetup
 
     @post = Post.new
     @comment = Comment.new
+    @format_thing = FormatThing.new
 
     if defined?(ActionView::OutputFlow)
       @view_flow        = ActionView::OutputFlow.new

--- a/test/action_view/cases/test_helpers.rb
+++ b/test/action_view/cases/test_helpers.rb
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 require 'action_view/cases/helper'
 
 class ClientSideValidations::ActionViewHelpersTest < ActionView::TestCase
@@ -635,6 +637,56 @@ class ClientSideValidations::ActionViewHelpersTest < ActionView::TestCase
     expected = whole_form('/posts', 'new_post', 'new_post', validators: validators) do
       form_field('input', 'post_cost', 'post[cost]', 'text')
     end.gsub("{\"separator\":\".\",\"delimiter\":\",\"}", "{\"separator\":\",\",\"delimiter\":\".\"}").gsub("(?:\\,\\d{3})+)(?:\\.\\d*)", "(?:\\.\\d{3})+)(?:\\,\\d*)")
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_field_with_format_a
+    assert_field_with_format_has_source(:a, 'a')
+  end
+
+  def test_field_with_format_backslash
+    assert_field_with_format_has_source(:backslash, '\\\\\\\\')
+  end
+
+  def test_field_with_format_space
+    # regression test for issue #460
+    assert_field_with_format_has_source(:space, ' ')
+  end
+
+  def test_field_with_format_escaped_space
+    assert_field_with_format_has_source(:escaped_space, '\\\\ ')
+  end
+
+  def test_field_with_format_ascii_escape
+    assert_field_with_format_has_source(:ascii_escape, '\\\\x41')
+  end
+
+  def test_field_with_format_unicode_escape
+    assert_field_with_format_has_source(:unicode_escape, '\\\\u263A')
+  end
+
+  def test_field_with_format_unicode_literal
+    assert_field_with_format_has_source(:unicode_literal, '☺')
+  end
+
+  def test_field_with_format_newline_escape
+    assert_field_with_format_has_source(:newline_escape, '\\\\n')
+  end
+
+  def test_field_with_format_newline_literal
+    assert_field_with_format_has_source(:newline_literal, '\\\\n')
+  end
+
+  def assert_field_with_format_has_source(field, expected_source)
+    form_for(@format_thing, validate: true) do |f|
+      concat f.text_field(field)
+    end
+
+    validators = {"format_thing[#{field}]" => {format: [{message: 'is invalid', with: {source: expected_source, options: 'g'}}]}}
+    expected = whole_form('/format_things', 'new_format_thing', 'new_format_thing', validators: validators) do
+      form_field('input', "format_thing_#{field}", "format_thing[#{field}]", 'text')
+    end
 
     assert_dom_equal expected, output_buffer
   end

--- a/test/action_view/models.rb
+++ b/test/action_view/models.rb
@@ -1,4 +1,5 @@
 require 'active_model'
 require 'client_side_validations/active_model'
 require 'action_view/models/comment'
+require 'action_view/models/format_thing'
 require 'action_view/models/post'

--- a/test/action_view/models/format_thing.rb
+++ b/test/action_view/models/format_thing.rb
@@ -1,0 +1,39 @@
+# -*- encoding: utf-8 -*-
+
+class FormatThing
+  extend  ActiveModel::Naming
+  extend  ActiveModel::Translation
+  include ActiveModel::Validations
+  include ActiveModel::Conversion
+
+  attr_accessor :a,
+                :backslash,
+                :space,
+                :escaped_space,
+                :ascii_escape,
+                :unicode_escape,
+                :unicode_literal,
+                :newline_escape,
+                :newline_literal
+
+  validates_format_of :a, with: /a/
+  validates_format_of :backslash, with: /\\/
+  validates_format_of :space, with: / /
+  validates_format_of :escaped_space, with: /\ /
+  validates_format_of :ascii_escape, with: /\x41/
+  validates_format_of :unicode_escape, with: /\u263A/
+  validates_format_of :unicode_literal, with: /☺/
+  validates_format_of :newline_escape, with: /\n/
+  validates_format_of :newline_literal, with: /
+/
+
+  def initialize(params={})
+    params.each do |attr, value|
+      self.public_send("#{attr}=", value)
+    end if params
+  end
+
+  def persisted?
+    false
+  end
+end

--- a/test/core_ext/cases/test_core_ext.rb
+++ b/test/core_ext/cases/test_core_ext.rb
@@ -3,49 +3,49 @@ require 'client_side_validations/core_ext'
 
 class CoreExtTest < MiniTest::Test
   def test_regexp_replace_A_and_Z
-    test_regexp = /\A\Z/
-    expected_regexp = { source: '^$', options: '' }
+    test_regexp = /\A\Z/ # \Z allows optional newline before end
+    expected_regexp = { source: '^(?=\\\\n?$)', options: 'g' }
     assert_equal expected_regexp, test_regexp.as_json
   end
 
   def test_regexp_replace_a_and_z
     test_regexp = /\A\z/
-    expected_regexp = { source: '^$', options: '' }
+    expected_regexp = { source: '^$', options: 'g' }
     assert_equal expected_regexp, test_regexp.as_json
   end
 
   def test_regexp_to_json
-    expected_regexp = { source: '^$', options: '' }
-    assert_equal expected_regexp, /\A\Z/.to_json(nil)
+    expected_regexp = { source: '^$', options: 'g' }
+    assert_equal expected_regexp, /\A\z/.to_json(nil)
   end
 
   def test_regexp_in_hash_to_json
-    expected_regexp = { hello: { source: 'world', options: 'i' } }
+    expected_regexp = { hello: { source: 'world', options: 'gi' } }
     hash = { hello: /world/i }
     assert_equal expected_regexp.to_json, hash.to_json
   end
 
   def test_regexp_encode_json
-    assert_equal "//", //.encode_json(nil)
+    assert_equal '//', //.encode_json(nil)
   end
 
   def test_regexp_remove_comment
-    expected_regexp = { source: '', options: '' }
+    expected_regexp = { source: '', options: 'g' }
     assert_equal expected_regexp, /(?# comment)/.to_json(nil)
   end
 
   def test_regexp_remove_group_options
-    expected_regexp = { source: '(something)', options: '' }
+    expected_regexp = { source: '(something)', options: 'g' }
     assert_equal expected_regexp, /(?-mix:something)/.to_json(nil)
   end
 
   def test_regexp_as_json_with_options
-    expected_regexp = { source: '', options: 'i' }
+    expected_regexp = { source: '', options: 'gi' }
     assert_equal expected_regexp, //i.as_json
   end
 
   def test_range_as_json
-    assert_equal [1,3], (1..3).as_json
+    assert_equal [1, 3], (1..3).as_json
   end
 
   def test_range_to_json
@@ -53,23 +53,50 @@ class CoreExtTest < MiniTest::Test
   end
 
   def test_range_as_json_with_floats
-    assert_equal [0.5,5.5], (0.5..5.5).as_json
+    assert_equal [0.5, 5.5], (0.5..5.5).as_json
   end
 
   def test_multiline_regexp_as_json
+    # A regexp with a line break in it WILL match line breaks in Ruby
+    # if the extended option /x is not set. It WILL also match any
+    # spaces with which the line that follows the line break is indented.
     test_regexp = /
-    /
-    expected_regexp = { source: '', options: '' }
+/
+    expected_regexp = { source: '\\\\n', options: 'g' }
+    assert_equal expected_regexp, test_regexp.as_json
+  end
+
+  def test_regexp_with_literal_whitespace_as_json
+    # regression test for issue #460
+    test_regexp = / /
+    expected_regexp = { source: ' ', options: 'g' }
+    assert_equal expected_regexp, test_regexp.as_json
+  end
+
+  def test_regexp_with_unicode_properties_as_json
+    # regression test for issue #615
+    # The double backslashes are needed by JS' new RegExp() constructor.
+    test_regexp = /\p{ASCII}/
+    expected_regexp = { source: '[\\\\x00-\\\\x7F]', options: 'g' }
+    assert_equal expected_regexp, test_regexp.as_json
+  end
+
+  def test_extended_mode_regexp_with_escaped_whitespace_as_json
+    # regression test for issue #625
+    test_regexp = /    [\ a]\    /x
+    expected_regexp = { source: '[\\\\ a]\\\\ ', options: 'g' }
     assert_equal expected_regexp, test_regexp.as_json
   end
 
   def test_regexp_modifiers_as_json
-    # JS allows /i and /m modifiers, all other lead to error
-    assert_equal(({ source: '', options: 'i' }), //i.as_json)
-    assert_equal(({ source: '', options: 'm' }), //m.as_json)
-    assert_equal(({ source: '', options: 'im' }), //im.as_json)
-    assert_equal(({ source: '', options: '' }), //x.as_json)
-    assert_equal(({ source: '', options: 'i' }), //ix.as_json)
+    # - All Ruby regexes are what is considered "global" (/g) in JS.
+    # - JS has the same /i option as Ruby, so this should be transferred.
+    # - /m in JS has nothing to do with /m in Ruby. Ruby's /m can only be
+    #   achieved in JS by modifying the source, not by setting /m.
+    assert_equal(({ source: '', options: 'gi' }), //i.as_json)
+    assert_equal(({ source: '', options: 'g' }), //m.as_json)
+    assert_equal(({ source: '', options: 'gi' }), //im.as_json)
+    assert_equal(({ source: '', options: 'g' }), //x.as_json)
+    assert_equal(({ source: '', options: 'gi' }), //ix.as_json)
   end
-
 end


### PR DESCRIPTION
Using the gem [JsRegex](https://github.com/janosch-x/js_regex) to translate Ruby regexes to JavaScript would greatly improve client side format validation, and solve issues #460, #615, #625.

This pull request does not yet make use of JsRegex' [warning capabilities](https://github.com/janosch-x/js_regex#user-content-HW). That might make sense to indicate any remaining conversion problems, but there is not really any room to do that in the given structure, except perhaps by raising an exception or printing the warnings to Rails' logger.