### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ There is additional support for other `ActiveModel` based ORMs and other
 Rails `FormBuilders`. Please see the [Plugin wiki page](https://github.com/DavyJonesLocker/client_side_validations/wiki/Plugins)
 (feel free to add your own)
 
-* [SimpleForm](https://github.com/DockYard/client_side_validations-simple_form)
-* [Formtastic](https://github.com/DockYard/client_side_validations-formtastic)
-* [Mongoid](https://github.com/DockYard/client_side_validations-mongoid)
-* [MongoMapper](https://github.com/DockYard/client_side_validations-mongo_mapper)
+* [SimpleForm](https://github.com/DavyJonesLocker/client_side_validations-simple_form)
+* [Formtastic](https://github.com/DavyJonesLocker/client_side_validations-formtastic)
+* [Mongoid](https://github.com/DavyJonesLocker/client_side_validations-mongoid)
+* [MongoMapper](https://github.com/DavyJonesLocker/client_side_validations-mongo_mapper)
 
 ## Usage ##
 
@@ -504,9 +504,9 @@ Note that the `FormBuilder` will automatically skip building validators that are
 
 ## Authors ##
 
-[Brian Cardarella](http://twitter.com/bcardarella)
+[Brian Cardarella](https://twitter.com/bcardarella)
 
-[Geremia Taglialatela](http://twitter.com/gtagliala)
+[Geremia Taglialatela](https://twitter.com/gtagliala)
 
 [We are very thankful for the many contributors](https://github.com/DavyJonesLocker/client_side_validations/graphs/contributors)
 
@@ -533,8 +533,8 @@ on how to properly submit issues and pull requests.
 
 ## Legal ##
 
-[DockYard](http://dockyard.com), LLC &copy; 2012-2015
+[DockYard](https://dockyard.com/), LLC &copy; 2012-2015
 
-[@dockyard](http://twitter.com/dockyard)
+[@dockyard](https://twitter.com/dockyard)
 
-[Licensed under the MIT license](http://www.opensource.org/licenses/mit-license.php)
+[Licensed under the MIT license](https://opensource.org/licenses/mit-license.php)


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/DockYard/client_side_validations-formtastic | https://github.com/DavyJonesLocker/client_side_validations-formtastic 
https://github.com/DockYard/client_side_validations-mongo_mapper | https://github.com/DavyJonesLocker/client_side_validations-mongo_mapper 
https://github.com/DockYard/client_side_validations-mongoid | https://github.com/DavyJonesLocker/client_side_validations-mongoid 
https://github.com/DockYard/client_side_validations-simple_form | https://github.com/DavyJonesLocker/client_side_validations-simple_form 


### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://twitter.com/bcardarella | https://twitter.com/bcardarella 
http://twitter.com/dockyard | https://twitter.com/dockyard 
http://twitter.com/gtagliala | https://twitter.com/gtagliala 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://dockyard.com | https://dockyard.com/ 
http://www.opensource.org/licenses/mit-license.php | https://opensource.org/licenses/mit-license.php 
