### PR TITLE
Choices for select should be an optional parameter

### DIFF
--- a/test/action_view/cases/test_helpers.rb
+++ b/test/action_view/cases/test_helpers.rb
@@ -688,8 +688,7 @@ module ClientSideValidations
 
     validators = {
       "format_thing[#{field}]" => { format: [{ message: 'is invalid', with:
-        { source: expected_source, options: 'g' } }]
-      }
+        { source: expected_source, options: 'g' } }] }
     }
 
     expected = whole_form('/format_things', 'new_format_thing', 'new_format_thing', validators: validators) do


### PR DESCRIPTION
When using select in block mode, choices need not be passed. For example, thoughtbot/administrate uses select tag helper as follows. Consistently reproducible when using with administrate.

So, I made choices an optional parameter with default nil.

```
ActionView::Template::Error (wrong number of arguments (given 1, expected 2..4)):
    20:   <%= f.label field.permitted_attribute %>
    21: </div>
    22: <div class="field-unit__field">
    23:   <%= f.select(field.permitted_attribute) do %>
    24:     <%= options_for_select(field.associated_resource_options, field.selected_option) %>
    25:   <% end %>
    26: </div>
  client_side_validations (4.2.4) lib/client_side_validations/action_view/form_builder.rb:71:in `select_with_client_side_validations'
```

I am quoting rails source code here and you can see that `choices` is optional. So, made `select_with_client_side_validations` consistent with the original `without` counterpart.

```
# File actionview/lib/action_view/helpers/form_options_helper.rb, line 162
def select(object, method, choices = nil, options = {}, html_options = {}, &block)
  Tags::Select.new(object, method, self, choices, options, html_options, &block).render
end
```