### PR TITLE
Fixed to use lambda in validation's condition(:if, :unless)

### DIFF
--- a/lib/client_side_validations/active_model.rb
+++ b/lib/client_side_validations/active_model.rb
@@ -81,7 +81,14 @@ module ClientSideValidations
 
       def run_conditional(method_name_value_or_proc)
         if method_name_value_or_proc.respond_to?(:call)
-          method_name_value_or_proc.call self
+          case method_name_value_or_proc.arity
+          when 0
+            instance_exec(&method_name_value_or_proc)
+          when 1
+            instance_exec(self, &method_name_value_or_proc)
+          else
+            raise ArgumentError, 'Missing argument'
+          end
         else
           send method_name_value_or_proc
         end

--- a/test/active_model/cases/test_validations.rb
+++ b/test/active_model/cases/test_validations.rb
@@ -303,6 +303,56 @@ module ActiveModel
       assert_equal expected_hash, person.client_side_validation_hash(true)
     end
 
+    def test_conditional_lambda_validators
+      person = new_person do |p|
+        p.validates :first_name, presence: { if: ->(o) { o.can_validate? } }
+        p.validates :last_name,  presence: { unless: ->(o) { o.cannot_validate? } }
+      end
+
+      person.stubs(:can_validate?).returns true
+      person.stubs(:cannot_validate?).returns false
+
+      expected_hash = {
+        first_name: {
+          presence: [{
+            message: "can't be blank"
+          }]
+        },
+        last_name: {
+          presence: [{
+            message: "can't be blank"
+          }]
+        }
+      }
+
+      assert_equal expected_hash, person.client_side_validation_hash(true)
+    end
+
+    def test_conditional_lambda_without_argument_validators
+      person = new_person do |p|
+        p.validates :first_name, presence: { if: -> { can_validate? } }
+        p.validates :last_name,  presence: { unless: -> { cannot_validate? } }
+      end
+
+      person.stubs(:can_validate?).returns true
+      person.stubs(:cannot_validate?).returns false
+
+      expected_hash = {
+        first_name: {
+          presence: [{
+            message: "can't be blank"
+          }]
+        },
+        last_name: {
+          presence: [{
+            message: "can't be blank"
+          }]
+        }
+      }
+
+      assert_equal expected_hash, person.client_side_validation_hash(true)
+    end
+
     def test_conditionals_forced_when_used_changed_helpers
       person = new_person do |p|
         p.validates :first_name, presence: { if: :first_name_changed? }

--- a/test/active_model/cases/test_validations.rb
+++ b/test/active_model/cases/test_validations.rb
@@ -328,6 +328,16 @@ module ActiveModel
       assert_equal expected_hash, person.client_side_validation_hash(true)
     end
 
+    def test_conditional_lambda_with_2_arguments_validators
+      person = new_person do |p|
+        p.validates :first_name, presence: { if: ->(_a, _b) { can_validate? } }
+      end
+
+      person.stubs(:can_validate?).returns true
+
+      assert_raises(ArgumentError) { person.client_side_validation_hash(true) }
+    end
+
     def test_conditional_lambda_without_argument_validators
       person = new_person do |p|
         p.validates :first_name, presence: { if: -> { can_validate? } }


### PR DESCRIPTION
There are some cases not to work well in current version when we use lambda in validation's condition.
- Condition doesn't have argument 
- `self` is not correct in lambda.