### PR TITLE
Fix conditionals

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ individual validators:
 
 In the above case only the `presence` validator will be passed to the client.
 
-This is also the case with Procs, or any object that responds to `#call`
+This is also the case with [other supported conditional validations](http://guides.rubyonrails.org/v4.2.0/active_record_validations.html#conditional-validation) (such as Procs, Arrays or Strings).
 
 ### Turning off validators ###
 

--- a/lib/client_side_validations/active_model.rb
+++ b/lib/client_side_validations/active_model.rb
@@ -81,7 +81,14 @@ module ClientSideValidations
 
       def run_conditional(method_name_value_or_proc)
         if method_name_value_or_proc.respond_to?(:call)
-          method_name_value_or_proc.call self
+          case method_name_value_or_proc.arity
+          when 0
+            instance_exec(&method_name_value_or_proc)
+          when 1
+            instance_exec(self, &method_name_value_or_proc)
+          else
+            raise ArgumentError, 'Missing argument'
+          end
         else
           send method_name_value_or_proc
         end

--- a/lib/client_side_validations/active_model.rb
+++ b/lib/client_side_validations/active_model.rb
@@ -31,7 +31,7 @@ module ClientSideValidations
           return attr_hash if [nil, :block].include?(attr[0])
 
           validator_hash = attr[1].each_with_object(Hash.new { |h, k| h[k] = [] }) do |validator, kind_hash|
-            next nil unless can_use_for_client_side_validation?(attr[0], validator, force)
+            next unless can_use_for_client_side_validation?(attr[0], validator, force)
 
             client_side_hash = validator.client_side_hash(self, attr[0], extract_force_option(attr[0], force))
             if client_side_hash
@@ -71,10 +71,10 @@ module ClientSideValidations
           else
             result = can_force_validator?(attr, validator, force)
             if validator.options[:if]
-              result &&= run_conditionals(validator.options[:if])
+              result &&= run_conditionals(validator.options[:if], :if)
             end
             if validator.options[:unless]
-              result &&= !run_conditionals(validator.options[:unless])
+              result &&= run_conditionals(validator.options[:unless], :unless)
             end
           end
         end

--- a/lib/client_side_validations/active_model/conditionals.rb
+++ b/lib/client_side_validations/active_model/conditionals.rb
@@ -1,0 +1,36 @@
+module ClientSideValidations
+  module ActiveModel
+    module Conditionals
+      private
+
+      def run_conditionals(conditionals)
+        Array.wrap(conditionals).inject(true) do |acc, conditional|
+          acc && run_one_conditional(conditional)
+        end
+      end
+
+      def run_one_conditional(conditional)
+        case conditional
+        when ::Proc
+          case conditional.arity
+          when 0
+            instance_exec(&conditional)
+          when 1
+            instance_exec(self, &conditional)
+          else
+            raise ArgumentError, 'Missing argument'
+          end
+        when String
+          # rubocop:disable Lint/Eval'
+          l = eval "lambda { |value| #{conditional} }"
+          # rubocop:enable Lint/Eval'
+          instance_exec(nil, &l)
+        when Symbol
+          send conditional
+        else
+          raise ArgumentError, "Unknown conditional #{conditional}. If supported by ActiveModel/ActiveRecord open a bug for client_side_validations gem."
+        end
+      end
+    end
+  end
+end

--- a/lib/client_side_validations/active_model/conditionals.rb
+++ b/lib/client_side_validations/active_model/conditionals.rb
@@ -3,9 +3,14 @@ module ClientSideValidations
     module Conditionals
       private
 
-      def run_conditionals(conditionals)
-        Array.wrap(conditionals).inject(true) do |acc, conditional|
-          acc && run_one_conditional(conditional)
+      def run_conditionals(conditionals, conditional_type)
+        Array.wrap(conditionals).all? do |conditional|
+          value = run_one_conditional(conditional)
+          if conditional_type == :unless
+            !value
+          else
+            value
+          end
         end
       end
 

--- a/test/active_model/cases/test_validations.rb
+++ b/test/active_model/cases/test_validations.rb
@@ -303,6 +303,56 @@ module ActiveModel
       assert_equal expected_hash, person.client_side_validation_hash(true)
     end
 
+    def test_conditional_lambda_validators
+      person = new_person do |p|
+        p.validates :first_name, presence: { if: ->(o) { o.can_validate? } }
+        p.validates :last_name,  presence: { unless: ->(o) { o.cannot_validate? } }
+      end
+
+      person.stubs(:can_validate?).returns true
+      person.stubs(:cannot_validate?).returns false
+
+      expected_hash = {
+        first_name: {
+          presence: [{
+            message: "can't be blank"
+          }]
+        },
+        last_name: {
+          presence: [{
+            message: "can't be blank"
+          }]
+        }
+      }
+
+      assert_equal expected_hash, person.client_side_validation_hash(true)
+    end
+
+    def test_conditional_lambda_without_argument_validators
+      person = new_person do |p|
+        p.validates :first_name, presence: { if: -> { can_validate? } }
+        p.validates :last_name,  presence: { unless: -> { cannot_validate? } }
+      end
+
+      person.stubs(:can_validate?).returns true
+      person.stubs(:cannot_validate?).returns false
+
+      expected_hash = {
+        first_name: {
+          presence: [{
+            message: "can't be blank"
+          }]
+        },
+        last_name: {
+          presence: [{
+            message: "can't be blank"
+          }]
+        }
+      }
+
+      assert_equal expected_hash, person.client_side_validation_hash(true)
+    end
+
     def test_conditionals_forced_when_used_changed_helpers
       person = new_person do |p|
         p.validates :first_name, presence: { if: :first_name_changed? }

--- a/test/active_model/cases/test_validations.rb
+++ b/test/active_model/cases/test_validations.rb
@@ -190,6 +190,31 @@ module ActiveModel
       assert_equal expected_hash, person.client_side_validation_hash(true)
     end
 
+    def test_conditionals_when_combination_is_given
+      person = new_person do |p|
+        p.validates :first_name, presence: { if: [:can_validate?, 'last_name.nil?', proc { |o| o.can_validate? }] }
+        p.validates :last_name,  presence: { unless: [:cannot_validate?, 'first_name.nil?', proc { |o| o.cannot_validate? }] }
+      end
+
+      person.stubs(:can_validate?).returns true
+      person.stubs(:cannot_validate?).returns false
+
+      expected_hash = {
+        first_name: {
+          presence: [{
+            message: "can't be blank"
+          }]
+        },
+        last_name: {
+          presence: [{
+            message: "can't be blank"
+          }]
+        }
+      }
+
+      assert_equal expected_hash, person.client_side_validation_hash(true)
+    end
+
     def test_conditionals_forcing_individual_attributes_on
       person = new_person do |p|
         p.validates :first_name, presence: { if: :can_validate? }, length: { is: 5, if: :can_validate? }

--- a/test/active_model/cases/test_validations.rb
+++ b/test/active_model/cases/test_validations.rb
@@ -328,6 +328,16 @@ module ActiveModel
       assert_equal expected_hash, person.client_side_validation_hash(true)
     end
 
+    def test_conditional_lambda_with_2_arguments_validators
+      person = new_person do |p|
+        p.validates :first_name, presence: { if: ->(_a, _b) { can_validate? } }
+      end
+
+      person.stubs(:can_validate?).returns true
+
+      assert_raises(ArgumentError) { person.client_side_validation_hash(true) }
+    end
+
     def test_conditional_lambda_without_argument_validators
       person = new_person do |p|
         p.validates :first_name, presence: { if: -> { can_validate? } }

--- a/test/active_model/cases/test_validations.rb
+++ b/test/active_model/cases/test_validations.rb
@@ -363,6 +363,16 @@ module ActiveModel
       assert_raises(ArgumentError) { person.client_side_validation_hash(true) }
     end
 
+    def test_conditional_unsupported_value
+      person = new_person do |p|
+        p.validates :first_name, presence: { if: 42 }
+      end
+
+      person.stubs(:can_validate?).returns true
+
+      assert_raises(ArgumentError) { person.client_side_validation_hash(true) }
+    end
+
     def test_conditional_lambda_without_argument_validators
       person = new_person do |p|
         p.validates :first_name, presence: { if: -> { can_validate? } }


### PR DESCRIPTION
Add support of all [documented ways](http://guides.rubyonrails.org/v4.2.0/active_record_validations.html#conditional-validation) of handling conditionals. This supersedes (includes) #685.

The code looks a bit weird, because the ActiveModel module is 100 lines, and adding more lines triggers rubocop warning (and failed specs).

I used [code from rails 4.2](https://github.com/rails/rails/blob/38fe5ae24476ef8808d5eb6366afe84ff43a3279/activesupport/lib/active_support/callbacks.rb#L429-L458) for inspiration, that's where `eval "lambda { |value| ... }"` comes from. As far as I can tell `value` is `nil`, most of the time for validation.

Please tell me if anything needs to be updated/change, I'm happy to incorporate any feedback.