### PR TITLE
Fix file_field helper

### DIFF
--- a/lib/client_side_validations/action_view/form_builder.rb
+++ b/lib/client_side_validations/action_view/form_builder.rb
@@ -3,7 +3,7 @@ module ClientSideValidations
     module Helpers
       module FormBuilder
         def self.prepended(base)
-          (base.field_helpers.map(&:to_s) - %w(apply_form_for_options! label check_box radio_button fields_for hidden_field)).each do |selector|
+          (base.field_helpers - %i(label check_box radio_button fields_for hidden_field file_field)).each do |selector|
             base.class_eval <<-RUBY_EVAL
               def #{selector}(method, options = {})
                 build_validation_options(method, options)
@@ -88,6 +88,12 @@ module ClientSideValidations
           build_validation_options(method, html_options.merge(name: options[:name]))
           html_options.delete(:validate)
           super(method, priority_zones, options, html_options)
+        end
+
+        def file_field(method, options = {})
+          build_validation_options(method, options)
+          options.delete(:validate)
+          super(method, options)
         end
 
         private

--- a/test/action_view/cases/test_helpers.rb
+++ b/test/action_view/cases/test_helpers.rb
@@ -42,7 +42,7 @@ module ClientSideValidations
     end
 
     def test_file_field
-      form_for(@post, validate: true, html: { multipart: true }) do |f|
+      form_for(@post, validate: true) do |f|
         concat f.file_field(:cost)
       end
 

--- a/test/action_view/cases/test_legacy_helpers.rb
+++ b/test/action_view/cases/test_legacy_helpers.rb
@@ -27,7 +27,7 @@ module ClientSideValidations
     end
 
     def test_file_field
-      form_for(@post, html: { multipart: true }) do |f|
+      form_for(@post) do |f|
         concat f.file_field(:cost)
       end
 


### PR DESCRIPTION
File fields automatically add `enctype="multipart/form-data"` attribute
to `<form>` tags. CSV was treating `file_field` as all other fields, so
`self.multipart = true` was skipped

Fix: #694