### PR TITLE
Deeply nested attributes

### DIFF
--- a/coffeescript/rails.validations.coffee
+++ b/coffeescript/rails.validations.coffee
@@ -48,10 +48,15 @@ initializeOnEvent =
     'ready'
 
 validatorsFor = (name, validators) ->
+  return validators[name] if validators.hasOwnProperty(name)
+
+  name = name.replace(/\[(\w+_attributes)\]\[[\da-z_]+\](?=\[(?:\w+_attributes)\])/g, "[$1][]")
+
   if captures = name.match /\[(\w+_attributes)\].*\[(\w+)\]$/
     for validator_name, validator of validators
       if validator_name.match "\\[#{captures[1]}\\].*\\[\\]\\[#{captures[2]}\\]$"
         name = name.replace /\[[\da-z_]+\]\[(\w+)\]$/g, '[][$1]'
+
   validators[name] || {}
 
 validateForm = (form, validators) ->

--- a/test/javascript/public/test/validateElement.js
+++ b/test/javascript/public/test/validateElement.js
@@ -15,6 +15,8 @@ QUnit.module('Validate Element', {
         'user[phone_numbers_attributes][][number]':{"presence":[{"message": "must be present"}]},
         'user[phone_numbers_attributes][country_code][][code]':{"presence":[{"message": "must be present"}]},
         'user[phone_numbers_attributes][deeply][nested][][attribute]':{"presence":[{"message": "must be present"}]},
+        'user[phone_numbers_attributes][][labels_attributes][][label]':{"presence":[{"message": "must be present"}]},
+        'user[a_attributes][][b_attributes][][c_attributes][][d_attributes][][e]':{"presence":[{"message": "must be present"}]},
         'customized_field':{"length":[{"messages":{"minimum":"is too short (minimum is 4 characters)"},"minimum":4}]}
       }
     }
@@ -97,6 +99,18 @@ QUnit.module('Validate Element', {
         .append($('<input />', {
           name: 'user[phone_numbers_attributes][deeply][nested][5154ce728c06dedad4000001][attribute]',
           id: 'user_phone_numbers_attributes_deeply_nested_5154ce728c06dedad4000001_attribute',
+          type: 'text'
+        }))
+        .append($('<label for="user_phone_numbers_attributes_1_labels_attributes_2_label">Two rails-nested-attributes</label>'))
+        .append($('<input />', {
+          name: 'user[phone_numbers_attributes][1][labels_attributes][2][label]',
+          id: 'user_phone_numbers_attributes_1_labels_attributes_2_label',
+          type: 'text'
+        }))
+        .append($('<label for="user_a_attributes_1_b_attributes_2_c_attributes_3_d_attributes_4_e">Two rails-nested-attributes</label>'))
+        .append($('<input />', {
+          name: 'user[a_attributes][1][b_attributes][2][c_attributes][3][d_attributes][4][e]',
+          id: 'user_a_attributes_1_b_attributes_2_c_attributes_3_d_attributes_4_e',
           type: 'text'
         }))
         .append($('<label for="user_info_attributes_eye_color">Eye Color</label>'))
@@ -194,6 +208,18 @@ QUnit.test('Validate nested attributes', function(assert) {
 
   input = form.find('input#user_phone_numbers_attributes_deeply_nested_5154ce728c06dedad4000001_attribute');
   label = $('label[for="user_phone_numbers_attributes_deeply_nested_5154ce728c06dedad4000001_attribute"]');
+  input.trigger('focusout');
+  assert.ok(input.parent().hasClass('field_with_errors'));
+  assert.ok(label.parent().hasClass('field_with_errors'));
+
+  input = form.find('input#user_phone_numbers_attributes_1_labels_attributes_2_label');
+  label = $('label[for="user_phone_numbers_attributes_1_labels_attributes_2_label"]');
+  input.trigger('focusout');
+  assert.ok(input.parent().hasClass('field_with_errors'));
+  assert.ok(label.parent().hasClass('field_with_errors'));
+
+  input = form.find('input#user_a_attributes_1_b_attributes_2_c_attributes_3_d_attributes_4_e');
+  label = $('label[for="user_a_attributes_1_b_attributes_2_c_attributes_3_d_attributes_4_e"]');
   input.trigger('focusout');
   assert.ok(input.parent().hasClass('field_with_errors'));
   assert.ok(label.parent().hasClass('field_with_errors'));

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -54,7 +54,14 @@
 
   validatorsFor = function(name, validators) {
     var captures, validator, validator_name;
-    if (captures = name.match(/\[(\w+_attributes)\].*\[(\w+)\]$/)) {
+    if (captures = name.match(/\[(\w+_attributes)\].*\[(\w+)\]\[(\w+_attributes)\]\[(\w+)\]\[(\w+)\]$/)) {
+      for (validator_name in validators) {
+        validator = validators[validator_name];
+        if (validator_name.match("\\[" + captures[1] + "\\].*\\[\\]\\[" + captures[3] + "\\].*\\[\\]\\[" + captures[5] + "\\]$")) {
+          name = name.replace(/\[(\d+)\]/g, '[]');
+        }
+      }
+    } else if (captures = name.match(/\[(\w+_attributes)\].*\[(\w+)\]$/)) {
       for (validator_name in validators) {
         validator = validators[validator_name];
         if (validator_name.match("\\[" + captures[1] + "\\].*\\[\\]\\[" + captures[2] + "\\]$")) {

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -54,14 +54,11 @@
 
   validatorsFor = function(name, validators) {
     var captures, validator, validator_name;
-    if (captures = name.match(/\[(\w+_attributes)\].*\[(\w+)\]\[(\w+_attributes)\]\[(\w+)\]\[(\w+)\]$/)) {
-      for (validator_name in validators) {
-        validator = validators[validator_name];
-        if (validator_name.match("\\[" + captures[1] + "\\].*\\[\\]\\[" + captures[3] + "\\].*\\[\\]\\[" + captures[5] + "\\]$")) {
-          name = name.replace(/\[(\d+)\]/g, '[]');
-        }
-      }
-    } else if (captures = name.match(/\[(\w+_attributes)\].*\[(\w+)\]$/)) {
+    if (validators.hasOwnProperty(name)) {
+      return validators[name];
+    }
+    name = name.replace(/\[(\w+_attributes)\]\[[\da-z_]+\](?=\[(?:\w+_attributes)\])/g, "[$1][]");
+    if (captures = name.match(/\[(\w+_attributes)\].*\[(\w+)\]$/)) {
       for (validator_name in validators) {
         validator = validators[validator_name];
         if (validator_name.match("\\[" + captures[1] + "\\].*\\[\\]\\[" + captures[2] + "\\]$")) {


### PR DESCRIPTION
Consider the following example:
    
```ruby
class User < ActiveRecord::Base
  has_many :phone_numbers

  accepts_nested_attributes_for :phone_numbers
end
    
class PhoneNumber < ActiveRecord::Base
  belongs_to :user
  # This is a bit contrived, because probably it should be many-to-many
  has_many :labels

  accepts_nested_attributes_for :labels
end

class Label < ActiveRecord::Base
  belongs_to :phone_number
end
```
    
If you render this on 1 page to edit labels you end up with the following attributes name:

```    
user[phone_numbers_attributes][0][labels_attributes][0][label]
```

Validation on this field will be generated automatically as:
```
user[phone_numbers_attributes][][label_attributes][][label]
```

The current nested attributes javascript looks like `/\[(\w+_attributes)\].*\[(\w+)\]$/`, which doesn't properly process this nested attributes, with this PR it'll be supported.

There's one use-case that is covered by the current deeply-nested validation, that I do not cover.
`user[phone_numbers_attributes][deeply][nested][][attribute]` searches for `/\[phone_numbers_attributes\].*\[\]\[attribute\]$/` in the validators. So it can match something unintended. I left it as it is right now and only process 

I left the initial commit of my colleague @arie in.

Any feedback welcome.
