### PR TITLE
Force validation when condition contains will_save_change_to to fix integration with devise

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ In the above case only the `presence` validator will be passed to the client.
 This is also the case with [other supported conditional validations](http://guides.rubyonrails.org/v4.2.0/active_record_validations.html#conditional-validation) (such as Procs, Arrays or Strings).
 
 **NOTE:** when `:if` conditional includes a symbol or a string with
-`changed?` in it, validator will forced automatically.
+`changed?` in it or start with `will_save_change_to`, validator will forced automatically.
 
 ```ruby
 class Person < ActiveRecord::Base

--- a/lib/client_side_validations/active_model.rb
+++ b/lib/client_side_validations/active_model.rb
@@ -83,8 +83,12 @@ module ClientSideValidations
         (respond_to?(:new_record?) && validator.options[:on] == (new_record? ? :create : :update)) || validator.options[:on].nil?
       end
 
+      def change_helper_validator?(validator)
+        validator.options[:if] =~ /changed\?/ || validator.options[:if] =~ /will_save_change_to/
+      end
+
       def check_conditionals(attr, validator, force)
-        return true if validator.options[:if] && validator.options[:if] =~ /changed\?/
+        return true if validator.options[:if] && change_helper_validator?(validator)
 
         result = can_force_validator?(attr, validator, force)
 

--- a/test/active_model/cases/test_validations.rb
+++ b/test/active_model/cases/test_validations.rb
@@ -463,6 +463,23 @@ module ActiveModel
       assert_equal expected_hash, person.client_side_validation_hash
     end
 
+    def test_conditionals_forced_when_used_will_save_change_to_helpers
+      person = new_person do |p|
+        p.validates :first_name, presence: { if: :will_save_change_to_first_name? }
+        p.validates :last_name,  presence: { unless: :will_save_change_to_last_name? }
+      end
+
+      expected_hash = {
+        first_name: {
+          presence: [{
+            message: "can't be blank"
+          }]
+        }
+      }
+
+      assert_equal expected_hash, person.client_side_validation_hash
+    end
+
     def test_multiple_validators_of_same_type_on_same_attribute
       person = new_person do |p|
         p.validates :first_name, format: /\d/


### PR DESCRIPTION
Hello,
As you see in this [issue](https://github.com/plataformatec/devise/issues/4574) Devise email validation is no longer working with client side validation.
I checked it out and I found that they changed the validator condition from `email_changed?` to `will_save_change_to_email?`.
So I created a PR to fix this problem, I hope it is useful.
Thanks a lot.