### PR TITLE
Update js_regex dependency

### DIFF
--- a/client_side_validations.gemspec
+++ b/client_side_validations.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rails', '>= 5.0.0.1', '< 5.2'
   spec.add_dependency 'jquery-rails', '~> 4.3'
-  spec.add_dependency 'js_regex', '~> 1.2'
+  spec.add_dependency 'js_regex', '~> 2.0'
 
   spec.add_development_dependency 'appraisal', '~> 2.2'
   spec.add_development_dependency 'byebug', '~> 9.1'


### PR DESCRIPTION
I've just released `js_regex` 2.0.0 with [improved conversion capabilities](https://github.com/janosch-x/js_regex/blob/master/CHANGELOG.md).

the only breaking change is a change of the warnings feature.

as `client_side_validations` does not use the warnings feature, you can safely to update to the latest version of `js_regex`.