### PR TITLE
Fix document ready syntax to support jquery v3

### DIFF
--- a/coffeescript/rails.validations.coffee
+++ b/coffeescript/rails.validations.coffee
@@ -33,19 +33,6 @@ $.fn.isValid = (validators) ->
   else
     validateElement(obj, validatorsFor(@[0].name, validators))
 
-# Determine the proper event to listen to
-#
-# Turbolinks and Turbolinks Classic don't use the same event, so we will try to
-# detect Turbolinks Classic by the EVENT hash, which is not defined
-# in the new 5.0 version.
-initializeOnEvent =
-  if window.Turbolinks? and window.Turbolinks.supported
-    if window.Turbolinks.EVENTS?
-      'page:change'
-    else
-      'turbolinks:load'
-  else
-    'ready'
 
 validatorsFor = (name, validators) ->
   return validators[name] if validators.hasOwnProperty(name)
@@ -462,6 +449,9 @@ ClientSideValidations =
 # If new forms are dynamically introduced into the DOM, the .validate() method
 # must be invoked on that form
 if window.Turbolinks? and window.Turbolinks.supported
+  # Turbolinks and Turbolinks Classic don't use the same event, so we will try to
+  # detect Turbolinks Classic by the EVENT hash, which is not defined
+  # in the new 5.0 version.
   initializeOnEvent = if window.Turbolinks.EVENTS?
     'page:change'
   else

--- a/coffeescript/rails.validations.coffee
+++ b/coffeescript/rails.validations.coffee
@@ -461,7 +461,15 @@ ClientSideValidations =
 # Main hook
 # If new forms are dynamically introduced into the DOM, the .validate() method
 # must be invoked on that form
-$(document).on initializeOnEvent, ->
-  $(ClientSideValidations.selectors.forms).validate()
+if window.Turbolinks? and window.Turbolinks.supported
+  initializeOnEvent = if window.Turbolinks.EVENTS?
+    'page:change'
+  else
+    'turbolinks:load'
+  $(document).on initializeOnEvent, ->
+    $(ClientSideValidations.selectors.forms).validate()
+else
+  $ ->
+    $(ClientSideValidations.selectors.forms).validate()
 
 window.ClientSideValidations = ClientSideValidations

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -576,7 +576,9 @@
       return $(ClientSideValidations.selectors.forms).validate();
     });
   } else {
-    $(ClientSideValidations.selectors.forms.validate());
+    $(function() {
+      return $(ClientSideValidations.selectors.forms).validate();
+    });
   }
 
   window.ClientSideValidations = ClientSideValidations;

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -570,9 +570,14 @@
     }
   };
 
-  $(document).on(initializeOnEvent, function() {
-    return $(ClientSideValidations.selectors.forms).validate();
-  });
+  if ((window.Turbolinks != null) && window.Turbolinks.supported) {
+    initializeOnEvent = window.Turbolinks.EVENTS != null ? 'page:change' : 'turbolinks:load';
+    $(document).on(initializeOnEvent, function() {
+      return $(ClientSideValidations.selectors.forms).validate();
+    });
+  } else {
+    $(ClientSideValidations.selectors.forms.validate());
+  }
 
   window.ClientSideValidations = ClientSideValidations;
 


### PR DESCRIPTION
`$(document).on 'ready' ` is no longer supported. 

https://jquery.com/upgrade-guide/3.0/#breaking-change-on-quot-ready-quot-fn-removed