### PR TITLE
[Docs] Update README to include manual validation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ In your `FormBuilder` you only need to enable validations:
   ...
 ```
 
+Your form will now automatically validate when it is submitted. However if you'd like to manually validate the form:
+
+```js
+form = $('form')
+validators = form[0].ClientSideValidations.settings.validators
+form.isValid(validators)
+```
+
 That should be enough to get you going.
 
 


### PR DESCRIPTION
Since upgrading a couple of my forms broke as the manually validation steps have changed.

I couldn't find an example in the README so added one. Hopefully saves people searching through the source or old issues.