### PR TITLE
Remove 'g' flag from RegExp conversions

### DIFF
--- a/lib/client_side_validations/core_ext/regexp.rb
+++ b/lib/client_side_validations/core_ext/regexp.rb
@@ -4,7 +4,7 @@ require 'js_regex'
 
 class Regexp
   def as_json(*)
-    JsRegex.new(self, options: 'g').to_h
+    JsRegex.new(self).to_h
   end
 
   def to_json(options = nil)

--- a/test/action_view/cases/test_helpers.rb
+++ b/test/action_view/cases/test_helpers.rb
@@ -706,7 +706,7 @@ module ClientSideValidations
 
     validators = {
       "format_thing[#{field}]" => { format: [{ message: 'is invalid', with:
-        { source: expected_source, options: 'g' } }] }
+        { source: expected_source, options: '' } }] }
     }
 
     expected = whole_form('/format_things', 'new_format_thing', 'new_format_thing', validators: validators) do

--- a/test/core_ext/cases/test_core_ext.rb
+++ b/test/core_ext/cases/test_core_ext.rb
@@ -7,23 +7,23 @@ class CoreExtTest < MiniTest::Test
   def test_regexp_replace_uppercase_a_and_uppercase_z
     test_regexp = /\A\Z/
     # \Z allows optional newline before end of string
-    expected_regexp = { source: '^(?=\\n?$)', options: 'g' }
+    expected_regexp = { source: '^(?=\\n?$)', options: '' }
     assert_equal expected_regexp, test_regexp.as_json
   end
 
   def test_regexp_replace_uppercase_a_and_lowercase_z
     test_regexp = /\A\z/
-    expected_regexp = { source: '^$', options: 'g' }
+    expected_regexp = { source: '^$', options: '' }
     assert_equal expected_regexp, test_regexp.as_json
   end
 
   def test_regexp_to_json
-    expected_regexp = { source: '^$', options: 'g' }
+    expected_regexp = { source: '^$', options: '' }
     assert_equal expected_regexp, /\A\z/.to_json
   end
 
   def test_regexp_in_hash_to_json
-    expected_regexp = { hello: { source: 'world', options: 'gi' } }
+    expected_regexp = { hello: { source: 'world', options: 'i' } }
     hash = { hello: /world/i }
     assert_equal expected_regexp.to_json, hash.to_json
   end
@@ -33,17 +33,17 @@ class CoreExtTest < MiniTest::Test
   end
 
   def test_regexp_remove_comment
-    expected_regexp = { source: '', options: 'g' }
+    expected_regexp = { source: '', options: '' }
     assert_equal expected_regexp, /(?# comment)/.to_json
   end
 
   def test_regexp_convert_group_options
-    expected_regexp = { source: '(?:something)', options: 'g' }
+    expected_regexp = { source: '(?:something)', options: '' }
     assert_equal expected_regexp, /(?-mix:something)/.to_json
   end
 
   def test_regexp_as_json_with_options
-    expected_regexp = { source: '', options: 'gi' }
+    expected_regexp = { source: '', options: 'i' }
     assert_equal expected_regexp, //i.as_json
   end
 
@@ -65,14 +65,14 @@ class CoreExtTest < MiniTest::Test
     # spaces with which the line that follows the line break is indented.
     test_regexp = /
 /
-    expected_regexp = { source: '\\n', options: 'g' }
+    expected_regexp = { source: '\\n', options: '' }
     assert_equal expected_regexp, test_regexp.as_json
   end
 
   def test_regexp_with_literal_whitespace_as_json
     # regression test for issue #460
     test_regexp = / /
-    expected_regexp = { source: ' ', options: 'g' }
+    expected_regexp = { source: ' ', options: '' }
     assert_equal expected_regexp, test_regexp.as_json
   end
 
@@ -80,26 +80,25 @@ class CoreExtTest < MiniTest::Test
     # regression test for issue #615
     # The double backslashes are needed by JS' new RegExp() constructor.
     test_regexp = /\p{ASCII}/
-    expected_regexp = { source: '[\\x00-\\x7F]', options: 'g' }
+    expected_regexp = { source: '[\\x00-\\x7F]', options: '' }
     assert_equal expected_regexp, test_regexp.as_json
   end
 
   def test_extended_mode_regexp_with_escaped_whitespace_as_json
     # regression test for issue #625
     test_regexp = /    [\ a]\    /x
-    expected_regexp = { source: '[\\x20a]\\ ', options: 'g' }
+    expected_regexp = { source: '[\\x20a]\\ ', options: '' }
     assert_equal expected_regexp, test_regexp.as_json
   end
 
   def test_regexp_modifiers_as_json
-    # - All Ruby regexes are what is considered "global" (/g) in JS.
     # - JS has the same /i option as Ruby, so this should be transferred.
     # - /m in JS has nothing to do with /m in Ruby. Ruby's /m can only be
     #   achieved in JS by modifying the source, not by setting /m.
-    assert_equal({ source: '', options: 'gi' }, //i.as_json)
-    assert_equal({ source: '', options: 'gi' }, //im.as_json)
-    assert_equal({ source: '', options: 'gi' }, //ix.as_json)
-    assert_equal({ source: '', options: 'g'  }, //m.as_json)
-    assert_equal({ source: '', options: 'g'  }, //x.as_json)
+    assert_equal({ source: '', options: 'i' }, //i.as_json)
+    assert_equal({ source: '', options: 'i' }, //im.as_json)
+    assert_equal({ source: '', options: 'i' }, //ix.as_json)
+    assert_equal({ source: '', options: ''  }, //m.as_json)
+    assert_equal({ source: '', options: ''  }, //x.as_json)
   end
 end


### PR DESCRIPTION
While looking into https://github.com/janosch-x/js_regex/issues/8, I noticed that you manually added the "g" flag back in when you upgraded to js_regex 3.0.0.

The "g" flag is only useful for substring replacement or counting. It can safely be removed for your use case.

It is actually better to remove it. It might cause bugs if the JS ever changes in a certain way (involving re-use of a RegExp as described in https://github.com/janosch-x/js_regex/issues/5).

Cheers!