### PR TITLE
Guard against prototype extended arrays

### DIFF
--- a/dist/client-side-validations.esm.js
+++ b/dist/client-side-validations.esm.js
@@ -676,13 +676,15 @@ var afterValidate = function afterValidate(element) {
 
 var executeValidator = function executeValidator(validatorFunctions, validatorFunction, validatorOptions, element) {
   for (var validatorOption in validatorOptions) {
-    if (validatorOptions[validatorOption]) {
-      var message = validatorFunction.call(validatorFunctions, element, validatorOptions[validatorOption]);
+    if (!validatorOptions[validatorOption]) {
+      continue;
+    }
 
-      if (message) {
-        failElement(element, message);
-        return false;
-      }
+    var message = validatorFunction.call(validatorFunctions, element, validatorOptions[validatorOption]);
+
+    if (message) {
+      failElement(element, message);
+      return false;
     }
   }
 

--- a/dist/client-side-validations.esm.js
+++ b/dist/client-side-validations.esm.js
@@ -676,11 +676,13 @@ var afterValidate = function afterValidate(element) {
 
 var executeValidator = function executeValidator(validatorFunctions, validatorFunction, validatorOptions, element) {
   for (var validatorOption in validatorOptions) {
-    var message = validatorFunction.call(validatorFunctions, element, validatorOptions[validatorOption]);
+    if (validatorOptions[validatorOption]) {
+      var message = validatorFunction.call(validatorFunctions, element, validatorOptions[validatorOption]);
 
-    if (message) {
-      failElement(element, message);
-      return false;
+      if (message) {
+        failElement(element, message);
+        return false;
+      }
     }
   }
 

--- a/dist/client-side-validations.js
+++ b/dist/client-side-validations.js
@@ -682,13 +682,15 @@
 
   var executeValidator = function executeValidator(validatorFunctions, validatorFunction, validatorOptions, element) {
     for (var validatorOption in validatorOptions) {
-      if (validatorOptions[validatorOption]) {
-        var message = validatorFunction.call(validatorFunctions, element, validatorOptions[validatorOption]);
+      if (!validatorOptions[validatorOption]) {
+        continue;
+      }
 
-        if (message) {
-          failElement(element, message);
-          return false;
-        }
+      var message = validatorFunction.call(validatorFunctions, element, validatorOptions[validatorOption]);
+
+      if (message) {
+        failElement(element, message);
+        return false;
       }
     }
 

--- a/dist/client-side-validations.js
+++ b/dist/client-side-validations.js
@@ -682,11 +682,13 @@
 
   var executeValidator = function executeValidator(validatorFunctions, validatorFunction, validatorOptions, element) {
     for (var validatorOption in validatorOptions) {
-      var message = validatorFunction.call(validatorFunctions, element, validatorOptions[validatorOption]);
+      if (validatorOptions[validatorOption]) {
+        var message = validatorFunction.call(validatorFunctions, element, validatorOptions[validatorOption]);
 
-      if (message) {
-        failElement(element, message);
-        return false;
+        if (message) {
+          failElement(element, message);
+          return false;
+        }
       }
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -138,11 +138,13 @@ const afterValidate = (element) => {
 
 const executeValidator = (validatorFunctions, validatorFunction, validatorOptions, element) => {
   for (const validatorOption in validatorOptions) {
-    const message = validatorFunction.call(validatorFunctions, element, validatorOptions[validatorOption])
+    if (validatorOptions[validatorOption]) {
+      const message = validatorFunction.call(validatorFunctions, element, validatorOptions[validatorOption])
 
-    if (message) {
-      failElement(element, message)
-      return false
+      if (message) {
+        failElement(element, message)
+        return false
+      }
     }
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -138,13 +138,15 @@ const afterValidate = (element) => {
 
 const executeValidator = (validatorFunctions, validatorFunction, validatorOptions, element) => {
   for (const validatorOption in validatorOptions) {
-    if (validatorOptions[validatorOption]) {
-      const message = validatorFunction.call(validatorFunctions, element, validatorOptions[validatorOption])
+    if (!validatorOptions[validatorOption]) {
+      continue
+    }
 
-      if (message) {
-        failElement(element, message)
-        return false
-      }
+    const message = validatorFunction.call(validatorFunctions, element, validatorOptions[validatorOption])
+
+    if (message) {
+      failElement(element, message)
+      return false
     }
   }
 

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -682,13 +682,15 @@
 
   var executeValidator = function executeValidator(validatorFunctions, validatorFunction, validatorOptions, element) {
     for (var validatorOption in validatorOptions) {
-      if (validatorOptions[validatorOption]) {
-        var message = validatorFunction.call(validatorFunctions, element, validatorOptions[validatorOption]);
+      if (!validatorOptions[validatorOption]) {
+        continue;
+      }
 
-        if (message) {
-          failElement(element, message);
-          return false;
-        }
+      var message = validatorFunction.call(validatorFunctions, element, validatorOptions[validatorOption]);
+
+      if (message) {
+        failElement(element, message);
+        return false;
       }
     }
 

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -682,11 +682,13 @@
 
   var executeValidator = function executeValidator(validatorFunctions, validatorFunction, validatorOptions, element) {
     for (var validatorOption in validatorOptions) {
-      var message = validatorFunction.call(validatorFunctions, element, validatorOptions[validatorOption]);
+      if (validatorOptions[validatorOption]) {
+        var message = validatorFunction.call(validatorFunctions, element, validatorOptions[validatorOption]);
 
-      if (message) {
-        failElement(element, message);
-        return false;
+        if (message) {
+          failElement(element, message);
+          return false;
+        }
       }
     }
 


### PR DESCRIPTION
Certain frameworks like Ember extend the array type with additional properties. Although they can be disabled ( https://guides.emberjs.com/release/configuring-ember/disabling-prototype-extensions/ ), it would remove some helpful functionality. In the case, the iteration through the additional properties by the execute validator code can result in `undefined` being passed as the third argument. The code change guards against that case.