### PR TITLE
Fix validatorsFor with exact name match

### DIFF
--- a/dist/client-side-validations.esm.js
+++ b/dist/client-side-validations.esm.js
@@ -1,12 +1,14 @@
 /*!
  * Client Side Validations JS - v0.1.1 (https://github.com/DavyJonesLocker/client_side_validations)
- * Copyright (c) 2019 Geremia Taglialatela, Brian Cardarella
+ * Copyright (c) 2020 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */
 
 import $ from 'jquery';
 
 function _typeof(obj) {
+  "@babel/helpers - typeof";
+
   if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
     _typeof = function (obj) {
       return typeof obj;
@@ -634,7 +636,7 @@ var cleanElementName = function cleanElementName(elementName, validators) {
 };
 
 var validatorsFor = function validatorsFor(elementName, validators) {
-  if (Object.prototype.isPrototypeOf.call(validators, elementName)) {
+  if (Object.prototype.hasOwnProperty.call(validators, elementName)) {
     return validators[elementName];
   }
 

--- a/dist/client-side-validations.js
+++ b/dist/client-side-validations.js
@@ -1,6 +1,6 @@
 /*!
  * Client Side Validations JS - v0.1.1 (https://github.com/DavyJonesLocker/client_side_validations)
- * Copyright (c) 2019 Geremia Taglialatela, Brian Cardarella
+ * Copyright (c) 2020 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */
 
@@ -10,9 +10,11 @@
   (global = global || self, global.ClientSideValidations = factory(global.$));
 }(this, (function ($) { 'use strict';
 
-  $ = $ && $.hasOwnProperty('default') ? $['default'] : $;
+  $ = $ && Object.prototype.hasOwnProperty.call($, 'default') ? $['default'] : $;
 
   function _typeof(obj) {
+    "@babel/helpers - typeof";
+
     if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
       _typeof = function (obj) {
         return typeof obj;
@@ -640,7 +642,7 @@
   };
 
   var validatorsFor = function validatorsFor(elementName, validators) {
-    if (Object.prototype.isPrototypeOf.call(validators, elementName)) {
+    if (Object.prototype.hasOwnProperty.call(validators, elementName)) {
       return validators[elementName];
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -93,7 +93,7 @@ const cleanElementName = (elementName, validators) => {
 }
 
 const validatorsFor = (elementName, validators) => {
-  if (Object.prototype.isPrototypeOf.call(validators, elementName)) {
+  if (Object.prototype.hasOwnProperty.call(validators, elementName)) {
     return validators[elementName]
   }
 

--- a/test/javascript/public/test/validateElement.js
+++ b/test/javascript/public/test/validateElement.js
@@ -13,6 +13,7 @@ QUnit.module('Validate Element', {
         'user[email]': { uniqueness: [{ message: 'must be unique' }], presence: [{ message: 'must be present' }] },
         'user[info_attributes][eye_color]': { presence: [{ message: 'must be present' }] },
         'user[phone_numbers_attributes][][number]': { presence: [{ message: 'must be present' }] },
+        'user[phone_numbers_attributes][2][number]': { length: [{ messages: { minimum: 'is too short (minimum is 4 characters)' }, minimum: 4 }] },
         'user[phone_numbers_attributes][country_code][][code]': { presence: [{ message: 'must be present' }] },
         'user[phone_numbers_attributes][deeply][nested][][attribute]': { presence: [{ message: 'must be present' }] },
         'user[phone_numbers_attributes][][labels_attributes][][label]': { presence: [{ message: 'must be present' }] },
@@ -75,6 +76,12 @@ QUnit.module('Validate Element', {
       .append($('<input />', {
         name: 'user[phone_numbers_attributes][1][number]',
         id: 'user_phone_numbers_attributes_1_number',
+        type: 'text'
+      }))
+      .append($('<label for="user_phone_numbers_attributes_2_number">Phone Number</label>'))
+      .append($('<input />', {
+        name: 'user[phone_numbers_attributes][2][number]',
+        id: 'user_phone_numbers_attributes_2_number',
         type: 'text'
       }))
       .append($('<label for="user_phone_numbers_attributes_new_1234_number">Phone Number</label>'))
@@ -228,6 +235,16 @@ QUnit.test('Validate nested attributes', function (assert) {
   input.trigger('focusout')
   assert.ok(input.parent().hasClass('field_with_errors'))
   assert.ok(label.parent().hasClass('field_with_errors'))
+})
+
+QUnit.test('Validate nested attributes with custom validation', function (assert) {
+  var form = $('form#new_user')
+  var input = form.find('input#user_phone_numbers_attributes_2_number')
+  var label = $('label[for="user_phone_numbers_attributes_2_number"]')
+
+  input.val('1')
+  input.trigger('focusout')
+  assert.equal(input.parent().find('label').text(), 'is too short (minimum is 4 characters)')
 })
 
 QUnit.test('Validate additional attributes', function (assert) {

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -1,6 +1,6 @@
 /*!
  * Client Side Validations JS - v0.1.1 (https://github.com/DavyJonesLocker/client_side_validations)
- * Copyright (c) 2019 Geremia Taglialatela, Brian Cardarella
+ * Copyright (c) 2020 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */
 
@@ -10,9 +10,11 @@
   (global = global || self, global.ClientSideValidations = factory(global.$));
 }(this, (function ($) { 'use strict';
 
-  $ = $ && $.hasOwnProperty('default') ? $['default'] : $;
+  $ = $ && Object.prototype.hasOwnProperty.call($, 'default') ? $['default'] : $;
 
   function _typeof(obj) {
+    "@babel/helpers - typeof";
+
     if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
       _typeof = function (obj) {
         return typeof obj;
@@ -640,7 +642,7 @@
   };
 
   var validatorsFor = function validatorsFor(elementName, validators) {
-    if (Object.prototype.isPrototypeOf.call(validators, elementName)) {
+    if (Object.prototype.hasOwnProperty.call(validators, elementName)) {
       return validators[elementName];
     }
 


### PR DESCRIPTION
I guess this was auto-completion mistake?

It was originally like this, was changed in this commit https://github.com/DavyJonesLocker/client_side_validations/commit/14cdcd6d325c321ba54934d6f270ca4a7bb980cd

Like it is doesn't make sense since only objects or null can be prototypes