### PR TITLE
Feature/jquery 3 5 0 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 16.2.0 / 2020-04-10
+
+* [FEATURE] Add jQuery 3.5.0 compatibility ([#779](https://github.com/DavyJonesLocker/client_side_validations/pull/779))
+* [ENHANCEMENT] Test against latest Ruby versions
+* [ENHANCEMENT] Update development dependencies
+
 ## 16.1.1 / 2020-03-20
 
 * [BUGFIX] Fix custom validators for nested attributes ([#778](https://github.com/DavyJonesLocker/client_side_validations/pull/778))

--- a/dist/client-side-validations.esm.js
+++ b/dist/client-side-validations.esm.js
@@ -1,5 +1,5 @@
 /*!
- * Client Side Validations JS - v0.1.2 (https://github.com/DavyJonesLocker/client_side_validations)
+ * Client Side Validations JS - v0.1.3 (https://github.com/DavyJonesLocker/client_side_validations)
  * Copyright (c) 2020 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */

--- a/dist/client-side-validations.js
+++ b/dist/client-side-validations.js
@@ -1,5 +1,5 @@
 /*!
- * Client Side Validations JS - v0.1.2 (https://github.com/DavyJonesLocker/client_side_validations)
+ * Client Side Validations JS - v0.1.3 (https://github.com/DavyJonesLocker/client_side_validations)
  * Copyright (c) 2020 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */

--- a/lib/client_side_validations/action_view/form_builder.rb
+++ b/lib/client_side_validations/action_view/form_builder.rb
@@ -25,8 +25,8 @@ module ClientSideValidations
         def client_side_form_settings(_options, form_helper)
           {
             type:      self.class.to_s,
-            input_tag: form_helper.class.field_error_proc.call(%(<span id="input_tag" />),  Struct.new(:error_message, :tag_id).new([], '')),
-            label_tag: form_helper.class.field_error_proc.call(%(<label id="label_tag" />), Struct.new(:error_message, :tag_id).new([], ''))
+            input_tag: form_helper.class.field_error_proc.call(%(<span id="input_tag"></span>), Struct.new(:error_message, :tag_id).new([], '')),
+            label_tag: form_helper.class.field_error_proc.call(%(<label id="label_tag"></label>), Struct.new(:error_message, :tag_id).new([], ''))
           }
         end
 

--- a/lib/client_side_validations/version.rb
+++ b/lib/client_side_validations/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ClientSideValidations
-  VERSION = '16.1.1'
+  VERSION = '16.2.0'
 end

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
       "/vendor/"
     ]
   },
-  "version": "0.1.2",
+  "version": "0.1.3",
   "directories": {
     "lib": "lib",
     "test": "test"

--- a/test/action_view/cases/helper.rb
+++ b/test/action_view/cases/helper.rb
@@ -189,6 +189,14 @@ module ActionViewTestSetup
     form_with_text(action, id, html_class, local, (validators || no_validate), file) + snowman(method) + (contents || '') + '</form>'
   end
 
+  def client_side_form_settings_helper
+    {
+      type:      'ActionView::Helpers::FormBuilder',
+      input_tag: %(<span id="input_tag"></span>),
+      label_tag: %(<label id="label_tag"></label>)
+    }
+  end
+
   def csv_data_attribute(validators)
     {
       html_settings: client_side_form_settings_helper,

--- a/test/action_view/cases/test_form_for_helpers.rb
+++ b/test/action_view/cases/test_form_for_helpers.rb
@@ -3,19 +3,11 @@
 require 'action_view/cases/helper'
 
 module ClientSideValidations
-  class ActionViewHelpersTest < ::ActionView::TestCase
+  class FormForActionViewHelpersTest < ::ActionView::TestCase
     include ::ActionViewTestSetup
 
     cattr_accessor :field_error_proc
     @@field_error_proc = proc { |html_tag, _| html_tag }
-
-    def client_side_form_settings_helper
-      {
-        type:      'ActionView::Helpers::FormBuilder',
-        input_tag: %(<span id="input_tag" />),
-        label_tag: %(<label id="label_tag" />)
-      }
-    end
 
     def test_text_field
       form_for(@post, validate: true) do |f|

--- a/test/action_view/cases/test_form_with_helpers.rb
+++ b/test/action_view/cases/test_form_with_helpers.rb
@@ -4,19 +4,11 @@ require 'action_view/cases/helper'
 
 if ::ActionView::Helpers::FormHelper.method_defined?(:form_with)
   module ClientSideValidations
-    class ActionViewHelpersTest < ::ActionView::TestCase
+    class FormWithActionViewHelpersTest < ::ActionView::TestCase
       include ::ActionViewTestSetup
 
       cattr_accessor :field_error_proc
       @@field_error_proc = proc { |html_tag, _| html_tag }
-
-      def client_side_form_settings_helper
-        {
-          type:      'ActionView::Helpers::FormBuilder',
-          input_tag: %(<span id="input_tag" />),
-          label_tag: %(<label id="label_tag" />)
-        }
-      end
 
       def test_form_with_without_block
         form_with(model: @post, validate: true)

--- a/test/action_view/cases/test_legacy_form_for_helpers.rb
+++ b/test/action_view/cases/test_legacy_form_for_helpers.rb
@@ -3,7 +3,7 @@
 require 'action_view/cases/helper'
 
 module ClientSideValidations
-  class LegacyActionViewHelpersTest < ::ActionView::TestCase
+  class LegacyFormForActionViewHelpersTest < ::ActionView::TestCase
     include ::ActionViewTestSetup
 
     def test_text_field

--- a/test/action_view/cases/test_legacy_form_with_helpers.rb
+++ b/test/action_view/cases/test_legacy_form_with_helpers.rb
@@ -4,7 +4,7 @@ require 'action_view/cases/helper'
 
 if ::ActionView::Helpers::FormHelper.method_defined?(:form_with)
   module ClientSideValidations
-    class LegacyActionViewHelpersTest < ::ActionView::TestCase
+    class LegacyFormWithActionViewHelpersTest < ::ActionView::TestCase
       include ::ActionViewTestSetup
 
       def automatic_id(id)

--- a/test/javascript/public/test/callbacks/elementAfter.js
+++ b/test/javascript/public/test/callbacks/elementAfter.js
@@ -3,15 +3,15 @@ QUnit.module('Element Validate After Callback', {
     dataCsv = {
       html_settings: {
         type: 'ActionView::Helpers::FormBuilder',
-        input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
-        label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>'
+        input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
+        label_tag: '<div class="field_with_errors"><label id="label_tag"></label></div>'
       },
       validators: { 'user[name]': { presence: [{ message: 'must be present' }] } }
     }
 
     $('#qunit-fixture')
-      .append($('<span id="result" />'))
-      .append($('<form />', {
+      .append($('<span id="result">'))
+      .append($('<form>', {
         action: '/users',
         'data-client-side-validations': JSON.stringify(dataCsv),
         method: 'post',

--- a/test/javascript/public/test/callbacks/elementBefore.js
+++ b/test/javascript/public/test/callbacks/elementBefore.js
@@ -3,15 +3,15 @@ QUnit.module('Element Validate Before Callback', {
     dataCsv = {
       html_settings: {
         type: 'ActionView::Helpers::FormBuilder',
-        input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
-        label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>'
+        input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
+        label_tag: '<div class="field_with_errors"><label id="label_tag"></label></div>'
       },
       validators: { 'user[name]': { '{presence': [{ message: 'must be present' }] } }
     }
 
     $('#qunit-fixture')
-      .append($('<span id="result" />'))
-      .append($('<form />', {
+      .append($('<span id="result">'))
+      .append($('<form>', {
         action: '/users',
         'data-client-side-validations': JSON.stringify(dataCsv),
         method: 'post',

--- a/test/javascript/public/test/callbacks/elementFail.js
+++ b/test/javascript/public/test/callbacks/elementFail.js
@@ -3,15 +3,15 @@ QUnit.module('Element Validate Fail Callback', {
     dataCsv = {
       html_settings: {
         type: 'ActionView::Helpers::FormBuilder',
-        input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
-        label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>'
+        input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
+        label_tag: '<div class="field_with_errors"><label id="label_tag"></label></div>'
       },
       validators: { 'user[name]': { presence: [{ message: 'must be present' }] } }
     }
 
     $('#qunit-fixture')
-      .append($('<span id="result" />'))
-      .append($('<form />', {
+      .append($('<span id="result">'))
+      .append($('<form>', {
         action: '/users',
         'data-client-side-validations': JSON.stringify(dataCsv),
         method: 'post',

--- a/test/javascript/public/test/callbacks/elementPass.js
+++ b/test/javascript/public/test/callbacks/elementPass.js
@@ -3,15 +3,15 @@ QUnit.module('Element Validate Pass Callback', {
     dataCsv = {
       html_settings: {
         type: 'ActionView::Helpers::FormBuilder',
-        input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
-        label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>'
+        input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
+        label_tag: '<div class="field_with_errors"><label id="label_tag"></label></div>'
       },
       validators: { 'user[name]': { presence: [{ message: 'must be present' }] } }
     }
 
     $('#qunit-fixture')
-      .append($('<span id="result" />'))
-      .append($('<form />', {
+      .append($('<span id="result">'))
+      .append($('<form>', {
         action: '/users',
         'data-client-side-validations': JSON.stringify(dataCsv),
         method: 'post',

--- a/test/javascript/public/test/callbacks/formAfter.js
+++ b/test/javascript/public/test/callbacks/formAfter.js
@@ -3,15 +3,15 @@ QUnit.module('Form Validate After Callback', {
     dataCsv = {
       html_settings: {
         type: 'ActionView::Helpers::FormBuilder',
-        input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
-        label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>'
+        input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
+        label_tag: '<div class="field_with_errors"><label id="label_tag"></label></div>'
       },
       validators: { 'user[name]': { presence: [{ message: 'must be present' }] } }
     }
 
     $('#qunit-fixture')
-      .append($('<span id="result" />'))
-      .append($('<form />', {
+      .append($('<span id="result">'))
+      .append($('<form>', {
         action: '/users',
         'data-client-side-validations': JSON.stringify(dataCsv),
         method: 'post',

--- a/test/javascript/public/test/callbacks/formBefore.js
+++ b/test/javascript/public/test/callbacks/formBefore.js
@@ -3,15 +3,15 @@ QUnit.module('Form Validate Before Callback', {
     dataCsv = {
       html_settings: {
         type: 'ActionView::Helpers::FormBuilder',
-        input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
-        label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>'
+        input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
+        label_tag: '<div class="field_with_errors"><label id="label_tag"></label></div>'
       },
       validators: { 'user[name]': { presence: [{ message: 'must be present' }] } }
     }
 
     $('#qunit-fixture')
-      .append($('<span id="result" />'))
-      .append($('<form />', {
+      .append($('<span id="result">'))
+      .append($('<form>', {
         action: '/users',
         'data-client-side-validations': JSON.stringify(dataCsv),
         method: 'post',

--- a/test/javascript/public/test/callbacks/formFail.js
+++ b/test/javascript/public/test/callbacks/formFail.js
@@ -3,15 +3,15 @@ QUnit.module('Form Validate Fail Callback', {
     dataCsv = {
       html_settings: {
         type: 'ActionView::Helpers::FormBuilder',
-        input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
-        label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>'
+        input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
+        label_tag: '<div class="field_with_errors"><label id="label_tag"></label></div>'
       },
       validators: { 'user[name]': { presence: [{ message: 'must be present' }] } }
     }
 
     $('#qunit-fixture')
-      .append($('<span id="result" />'))
-      .append($('<form />', {
+      .append($('<span id="result">'))
+      .append($('<form>', {
         action: '/users',
         'data-client-side-validations': JSON.stringify(dataCsv),
         method: 'post',

--- a/test/javascript/public/test/callbacks/formPass.js
+++ b/test/javascript/public/test/callbacks/formPass.js
@@ -3,15 +3,15 @@ QUnit.module('Form Validate Pass Callback', {
     dataCsv = {
       html_settings: {
         type: 'ActionView::Helpers::FormBuilder',
-        input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
-        label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>'
+        input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
+        label_tag: '<div class="field_with_errors"><label id="label_tag"></label></div>'
       },
       validators: { 'user[name]': { presence: [{ message: 'must be present' }] } }
     }
 
     $('#qunit-fixture')
-      .append($('<span id="result" />'))
-      .append($('<form />', {
+      .append($('<span id="result">'))
+      .append($('<form>', {
         action: '/users',
         'data-client-side-validations': JSON.stringify(dataCsv),
         method: 'post',

--- a/test/javascript/public/test/form_builders/validateForm.js
+++ b/test/javascript/public/test/form_builders/validateForm.js
@@ -3,14 +3,14 @@ QUnit.module('Validate Form', {
     dataCsv = {
       html_settings: {
         type: 'ActionView::Helpers::FormBuilder',
-        input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
-        label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>'
+        input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
+        label_tag: '<div class="field_with_errors"><label id="label_tag"></label></div>'
       },
       validators: { 'user[name]': { presence: [{ message: 'must be present' }] } }
     }
 
     $('#qunit-fixture')
-      .append($('<form />', {
+      .append($('<form>', {
         action: '/users',
         'data-client-side-validations': JSON.stringify(dataCsv),
         method: 'post',
@@ -82,7 +82,7 @@ QUnit.test('Ensure ajax:beforeSend is not from a bubbled event (async)', functio
   var input = form.find('input#user_name')
 
   form
-    .append('<a />')
+    .append('<a>')
     .find('a').trigger('ajax:beforeSend')
 
   setTimeout(function () {

--- a/test/javascript/public/test/settings.js
+++ b/test/javascript/public/test/settings.js
@@ -1,7 +1,7 @@
 QUnit.config.urlConfig.push({
   id: 'jquery',
   label: 'jQuery version',
-  value: ['3.4.1', '3.4.1.slim', '3.4.0', '3.4.0.slim', '3.3.1', '3.3.1.slim', '3.2.1', '3.2.1.slim', '3.1.1', '3.1.1.slim', '3.0.0', '3.0.0.slim', '2.2.4', '2.1.4', '2.0.3', '1.12.4', '1.11.3'],
+  value: ['3.5.0', '3.5.0.slim', '3.4.1', '3.4.1.slim', '3.3.1', '3.3.1.slim', '3.2.1', '3.2.1.slim', '3.1.1', '3.1.1.slim', '3.0.0', '3.0.0.slim', '2.2.4', '2.1.4', '2.0.3', '1.12.4', '1.11.3'],
   tooltip: 'What jQuery Core version to test against'
 })
 

--- a/test/javascript/public/test/settings.js
+++ b/test/javascript/public/test/settings.js
@@ -13,7 +13,7 @@ $(document).on('submit', function (e) {
     var form = $(e.target)
     var action = form.attr('action')
     var name = 'form-frame' + jQuery.guid++
-    var iframe = $('<iframe name="' + name + '" />')
+    var iframe = $('<iframe>', { name: name })
 
     if (action && action.indexOf('iframe') < 0) form.attr('action', action + '?iframe=true')
     form.attr('target', name)

--- a/test/javascript/public/test/validateElement.js
+++ b/test/javascript/public/test/validateElement.js
@@ -3,8 +3,8 @@ QUnit.module('Validate Element', {
     dataCsv = {
       html_settings: {
         type: 'ActionView::Helpers::FormBuilder',
-        input_tag: '<div class="class_one class_two field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
-        label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>'
+        input_tag: '<div class="class_one class_two field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
+        label_tag: '<div class="field_with_errors"><label id="label_tag"></label></div>'
       },
       validators: {
         'user[name]': { presence: [{ message: 'must be present' }], format: [{ message: 'is invalid', 'with': { options: 'g', source: '\\d+' } }] },
@@ -23,7 +23,7 @@ QUnit.module('Validate Element', {
     }
 
     $('#qunit-fixture')
-      .append($('<form />', {
+      .append($('<form>', {
         action: '/users',
         'data-client-side-validations': JSON.stringify(dataCsv),
         method: 'post',
@@ -320,14 +320,14 @@ QUnit.test("Don't validate confirmation when not a validatable input", function 
   dataCsv = {
     html_options: {
       type: 'ActionView::Helpers::FormBuilder',
-      input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
-      label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>'
+      input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
+      label_tag: '<div class="field_with_errors"><label id="label_tag"></label></div>'
     },
     validators: { }
   }
 
   $('#qunit-fixture')
-    .append($('<form />', {
+    .append($('<form>', {
       action: '/users',
       'data-client-side-validations': JSON.stringify(dataCsv),
       method: 'post',
@@ -360,14 +360,14 @@ QUnit.test("Don't validate disabled inputs", function (assert) {
   dataCsv = {
     html_settings: {
       type: 'ActionView::Helpers::FormBuilder',
-      input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
-      label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>'
+      input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
+      label_tag: '<div class="field_with_errors"><label id="label_tag"></label></div>'
     },
     validators: { 'user_2[name]': { presence: { message: 'must be present' } } }
   }
 
   $('#qunit-fixture')
-    .append($('<form />', {
+    .append($('<form>', {
       action: '/users',
       'data-client-side-validations': JSON.stringify(dataCsv),
       method: 'post',
@@ -395,14 +395,14 @@ QUnit.test("Don't validate dynamically disabled inputs", function (assert) {
   dataCsv = {
     html_settings: {
       type: 'ActionView::Helpers::FormBuilder',
-      input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
-      label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>'
+      input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
+      label_tag: '<div class="field_with_errors"><label id="label_tag"></label></div>'
     },
     validators: { 'user_2[name]': { presence: { message: 'must be present' } } }
   }
 
   $('#qunit-fixture')
-    .append($('<form />', {
+    .append($('<form>', {
       action: '/users',
       'data-client-side-validations': JSON.stringify(dataCsv),
       method: 'post',
@@ -431,7 +431,7 @@ QUnit.test('ensure label is scoped to form', function (assert) {
   var label = $('label[for="user_name"]')
 
   $('#qunit-fixture')
-    .prepend($('<form />', { id: 'other_form', 'data-client-side-validations': {}.to_json })
+    .prepend($('<form>', { id: 'other_form', 'data-client-side-validations': {}.to_json })
       .append($('<label for="user_name">Name</label>')))
 
   var otherLabel = $('form#other_form').find('label')

--- a/test/javascript/public/test/validators/absence.js
+++ b/test/javascript/public/test/validators/absence.js
@@ -21,13 +21,13 @@ QUnit.test('when value is empty', function (assert) {
 })
 
 QUnit.test('when value is null from non-selected multi-select element', function (assert) {
-  var element = $('<select multiple="multiple" />')
+  var element = $('<select multiple="multiple">')
   var options = { message: 'failed validation' }
   assert.equal(ClientSideValidations.validators.local.absence(element, options), undefined)
 })
 
 QUnit.test('when value is not null from multi-select element', function (assert) {
-  var element = $('<select multiple="multiple" />')
+  var element = $('<select multiple="multiple">')
   var options = { message: 'failed validation' }
   element.append('<option value="selected-option">Option</option>')
   element.val('selected-option')
@@ -35,13 +35,13 @@ QUnit.test('when value is not null from multi-select element', function (assert)
 })
 
 QUnit.test('when value is null from select element', function (assert) {
-  var element = $('<select />')
+  var element = $('<select>')
   var options = { message: 'failed validation' }
   assert.equal(ClientSideValidations.validators.local.absence(element, options), undefined)
 })
 
 QUnit.test('when value is not null from select element', function (assert) {
-  var element = $('<select />')
+  var element = $('<select>')
   var options = { message: 'failed validation' }
   element.append('<option value="selected-option">Option</option>')
   element.val('selected-option')

--- a/test/javascript/public/test/validators/numericality.js
+++ b/test/javascript/public/test/validators/numericality.js
@@ -5,7 +5,7 @@ QUnit.module('Numericality options', {
     }
 
     $('#qunit-fixture')
-      .append($('<form />', {
+      .append($('<form>', {
         action: '/users',
         id: 'form',
         method: 'post',

--- a/test/javascript/public/test/validators/presence.js
+++ b/test/javascript/public/test/validators/presence.js
@@ -14,7 +14,7 @@ QUnit.test('when value is empty', function (assert) {
 })
 
 QUnit.test('when value is null from non-selected multi-select element', function (assert) {
-  var element = $('<select multiple="multiple />')
+  var element = $('<select multiple="multiple">')
   var options = { message: 'failed validation' }
   assert.equal(ClientSideValidations.validators.local.presence(element, options), 'failed validation')
 })

--- a/test/javascript/public/test/validators/uniqueness.js
+++ b/test/javascript/public/test/validators/uniqueness.js
@@ -4,14 +4,14 @@ QUnit.module('Uniqueness options', {
     dataCsv = {
       html_settings: {
         type: 'ActionView::Helpers::FormBuilder',
-        input_tag: '<div class="field_with_errors"><span id="input_tag" /><label class="message"></label></div>',
-        label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>'
+        input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label class="message"></label></div>',
+        label_tag: '<div class="field_with_errors"><label id="label_tag"></label></div>'
       },
       validators: { 'user[email]': { uniqueness: [{ message: 'must be unique', scope: { name: 'pass' } }] }, presence: [{ message: 'must be present' }] }
     }
 
     $('#qunit-fixture')
-      .append($('<form />', {
+      .append($('<form>', {
         action: '/users',
         'data-client-side-validations': JSON.stringify(dataCsv),
         method: 'post',
@@ -37,14 +37,14 @@ QUnit.test('when matching local case-insensitive uniqueness for nested has-many 
   dataCsv = {
     html_settings: {
       type: 'ActionView::Helpers::FormBuilder',
-      input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
-      label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>'
+      input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
+      label_tag: '<div class="field_with_errors"><label id="label_tag"></label></div>'
     },
     validators: { 'user[email]': { uniqueness: [{ message: 'must be unique' }] } }
   }
 
   $('#qunit-fixture')
-    .append($('<form />', {
+    .append($('<form>', {
       action: '/users',
       'data-client-side-validations': JSON.stringify(dataCsv),
       method: 'post',
@@ -76,14 +76,14 @@ QUnit.test('when matching case-sensitive local uniqueness for nested has-many re
   dataCsv = {
     html_settings: {
       type: 'ActionView::Helpers::FormBuilder',
-      input_tag: '<div class="field_with_errors"><span id="input_tag" /><label for="user_name" class="message"></label></div>',
-      label_tag: '<div class="field_with_errors"><label id="label_tag" /></div>'
+      input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
+      label_tag: '<div class="field_with_errors"><label id="label_tag"></label></div>'
     },
     validators: { 'user[email]': { uniqueness: [{ message: 'must be unique' }] } }
   }
 
   $('#qunit-fixture')
-    .append($('<form />', {
+    .append($('<form>', {
       action: '/users',
       'data-client-side-validations': JSON.stringify(dataCsv),
       method: 'post',

--- a/test/javascript/server.rb
+++ b/test/javascript/server.rb
@@ -27,7 +27,7 @@ end
 use AssetPath, urls: ['/vendor/assets/javascripts'], root: File.expand_path('../..', settings.root)
 use AssetPath, urls: ['/vendor/assets/javascripts'], root: File.expand_path('../', $LOAD_PATH.find { |p| p =~ /jquery-rails/ })
 
-DEFAULT_JQUERY_VERSION = '3.4.1'
+DEFAULT_JQUERY_VERSION = '3.5.0'
 QUNIT_VERSION          = '2.9.2'
 
 helpers do

--- a/test/javascript/views/index.erb
+++ b/test/javascript/views/index.erb
@@ -4,7 +4,6 @@
 <div id="qunit-fixture"></div>
 
 <%= script_tag "https://code.jquery.com/jquery-#{jquery_version}.min.js" %>
-<%= script_tag '/vendor/assets/javascripts/jquery_ujs.js' %>
 <%= script_tag '/vendor/assets/javascripts/rails.validations.js' %>
 <%= script_tag "https://code.jquery.com/qunit/qunit-#{qunit_version}.js" %>
 <%= script_tag 'settings' %>

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -1,5 +1,5 @@
 /*!
- * Client Side Validations JS - v0.1.2 (https://github.com/DavyJonesLocker/client_side_validations)
+ * Client Side Validations JS - v0.1.3 (https://github.com/DavyJonesLocker/client_side_validations)
  * Copyright (c) 2020 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */


### PR DESCRIPTION
Quoting from https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/

> ### Security Fix
> The main change in this release is a security fix, and it’s possible you will need to change your own code to adapt. Here’s why: jQuery used a regex in its `jQuery.htmlPrefilter` method to ensure that all closing tags were XHTML-compliant when passed to methods. For example, this prefilter ensured that a call like jQuery(`"<div class='hot' />"`) is actually converted to jQuery(`"<div class='hot'></div>"`). Recently, an issue was reported that demonstrated the regex could introduce a cross-site scripting (XSS) vulnerability.
>
> The HTML parser in jQuery <=3.4.1 usually did the right thing, but there were edge cases where parsing would have unintended consequences. The jQuery team agreed it was necessary to fix this in a minor release, even though some code relies on the previous behavior and may break. The jQuery.htmlPrefilter function does not use a regex in 3.5.0 and passes the string through unchanged.

This PR:
- Tests against jQuery 3.5.0
- Fixes JS tests
- Fixes Ruby tests
- Changes the default `input_tag` and `label_tag` to XHTML-compliant tags