### PR TITLE
Add support for many association validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [FEATURE] Drop Ruby 2.3 support
+* [FEATURE] Add support for many association validations ([#783](https://github.com/DavyJonesLocker/client_side_validations/pull/783))
 
 ## 16.2.0 / 2020-04-10
 

--- a/lib/client_side_validations/action_view/form_helper.rb
+++ b/lib/client_side_validations/action_view/form_helper.rb
@@ -99,12 +99,15 @@ module ClientSideValidations
           if validation_hash.key?(attr)
             validator_hash[name] = validation_hash[attr]
           elsif attr.to_s.ends_with?('_id')
-            add_validator_with_association validator_hash, validation_hash, name, attr
+            association_name = attr.to_s.gsub(/_id\Z/, '').to_sym
+            add_validator_with_association validator_hash, validation_hash, name, association_name
+          elsif attr.to_s.ends_with?('_ids')
+            association_name = attr.to_s.gsub(/_ids\Z/, '').pluralize.to_sym
+            add_validator_with_association validator_hash, validation_hash, name, association_name
           end
         end
 
-        def add_validator_with_association(validator_hash, validation_hash, name, attr)
-          association_name = attr.to_s.gsub(/_id\Z/, '').to_sym
+        def add_validator_with_association(validator_hash, validation_hash, name, association_name)
           return unless validation_hash.key?(association_name)
 
           validator_hash[name] = validation_hash[association_name]

--- a/test/action_view/cases/test_form_for_helpers.rb
+++ b/test/action_view/cases/test_form_for_helpers.rb
@@ -383,6 +383,30 @@ module ClientSideValidations
       assert_dom_equal expected, output_buffer
     end
 
+    def test_collection_check_boxes_with_many_association
+      form_for(@post, validate: true) do |f|
+        concat f.collection_check_boxes(:tag_ids, [], :id, :title)
+      end
+
+      validators = {
+        'post[tag_ids]' => {
+          length: [{
+            messages: {
+              minimum: 'is too short (minimum is 0 characters)',
+              maximum: 'is too long (maximum is 3 characters)'
+            },
+            minimum:  0,
+            maximum:  3
+          }]
+        }
+      }
+
+      expected = whole_form_for('/posts', 'new_post', 'new_post', validators: validators) do
+        form_field('input', name: 'post[tag_ids][]', type: 'hidden', value: '')
+      end
+      assert_dom_equal expected, output_buffer
+    end
+
     def test_collection_select_with_validate_options
       form_for(@post, validate: true) do |f|
         concat f.collection_select(:cost, [], :id, :name, {}, validate: false)

--- a/test/action_view/models/post.rb
+++ b/test/action_view/models/post.rb
@@ -9,6 +9,7 @@ class Post
   attr_accessor :title, :author_name, :body, :secret, :written_on, :cost
   validates :cost, :body, presence: true
   validates :body, length: { minimum: 200 }
+  validates :tags, length: { minimum: 0, maximum: 3 }
 
   # Simulate default Rails 5's association
   validates :category, presence: { message: :required }
@@ -28,4 +29,7 @@ class Post
 
   attr_accessor :category, :category_id
   def category_attributes=(attributes); end
+
+  attr_accessor :tags, :tag_ids
+  def tags_attributes=(attributes); end
 end

--- a/test/action_view/models/tag.rb
+++ b/test/action_view/models/tag.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Tag
+  extend ActiveModel::Naming
+  extend ActiveModel::Translation
+  include ActiveModel::Validations
+  include ActiveModel::Conversion
+
+  attr_reader :id, :title, :description
+
+  def initialize(params = {})
+    params.each do |attr, value|
+      public_send("#{attr}=", value)
+    end
+  end
+
+  def persisted?
+    false
+  end
+end


### PR DESCRIPTION
This commit adds support for HABTM input validations, where form field
`model_ids` may have an associated `:models` validation in the model