### PR TITLE
Do not explicitly require jquery-rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [FEATURE] Drop Ruby 2.3 support
+* [FEATURE] Do not require `jquery-rails` gem ([#785](https://github.com/DavyJonesLocker/client_side_validations/pull/785))
 * [FEATURE] Add support for many association validations ([#783](https://github.com/DavyJonesLocker/client_side_validations/pull/783))
 
 ## 16.2.0 / 2020-04-10

--- a/README.md
+++ b/README.md
@@ -92,9 +92,26 @@ attach its event handlers.
 
 ####  When using Sprockets ####
 
-Make sure that you are requiring jQuery.
+Since ClientSideValidations can also be used via webpacker, it does not require
+by default `jquery-rails` gem.
 
-Add the following to your `app/assets/javascripts/application.js` file.
+Make sure that `jquery-rails` is part of your bundled gems and `application.js`,
+otherwise add:
+
+```ruby
+gem 'jquery-rails', '~> 4.3'
+```
+
+to your `Gemfile`, run `bundle`, and add
+
+```js
+//= require jquery
+```
+
+to your `app/assets/javascripts/application.js` file.
+
+Then, add the following to your `app/assets/javascripts/application.js` file
+after `//= require jquery`.
 
 ```js
 //= require rails.validations

--- a/client_side_validations.gemspec
+++ b/client_side_validations.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rails', '>= 5.0.0.1', '< 6.1'
 
-  spec.add_dependency 'jquery-rails', '~> 4.3'
   spec.add_dependency 'js_regex', '~> 3.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.2'


### PR DESCRIPTION
Since CSV can also be loaded via webpacker, there is no need to
explicitly require jquery-rails dependency.