### PR TITLE
Fix generator to take into account webpacker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [FEATURE] Drop Ruby 2.3 support
 * [FEATURE] Do not require `jquery-rails` gem ([#785](https://github.com/DavyJonesLocker/client_side_validations/pull/785))
 * [FEATURE] Add support for many association validations ([#783](https://github.com/DavyJonesLocker/client_side_validations/pull/783))
+* [BUGFIX] Fix Rails generators ([#786](https://github.com/DavyJonesLocker/client_side_validations/pull/786))
 
 ## 16.2.0 / 2020-04-10
 

--- a/lib/generators/client_side_validations/copy_assets_generator.rb
+++ b/lib/generators/client_side_validations/copy_assets_generator.rb
@@ -4,7 +4,7 @@ module ClientSideValidations
   module Generators
     class CopyAssetsGenerator < Rails::Generators::Base
       def copy_javascript_asset
-        return unless self.class == CopyAssetsGenerator || !asset_pipeline_enabled?
+        return unless self.class == CopyAssetsGenerator || copy_assets?
 
         assets.each do |asset|
           source_paths << asset[:path]
@@ -13,7 +13,7 @@ module ClientSideValidations
       end
 
       def self.asset_directory
-        if asset_pipeline_enabled?
+        if sprockets?
           "app#{Rails.configuration.assets.prefix}/javascripts"
         else
           'public/javascripts'
@@ -28,9 +28,16 @@ module ClientSideValidations
         assets.map { |asset| asset[:file] }.join(', ')
       end
 
-      def self.asset_pipeline_enabled?
-        # Rails 4.1 doesn't provide :enabled in asset configuration, so we look for Sprockets
-        defined?(Sprockets).present?
+      def self.copy_assets?
+        !sprockets? && !webpacker?
+      end
+
+      def self.sprockets?
+        defined?(Sprockets)
+      end
+
+      def self.webpacker?
+        defined?(Webpacker)
       end
 
       def self.installation_message
@@ -49,8 +56,8 @@ module ClientSideValidations
         CopyAssetsGenerator.assets
       end
 
-      def asset_pipeline_enabled?
-        self.class.asset_pipeline_enabled?
+      def copy_assets?
+        self.class.copy_assets?
       end
     end
   end

--- a/lib/generators/client_side_validations/install_generator.rb
+++ b/lib/generators/client_side_validations/install_generator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'generators/client_side_validations/copy_assets_generator'
+require_relative 'copy_assets_generator'
 
 module ClientSideValidations
   module Generators

--- a/test/generators/cases/test_generators.rb
+++ b/test/generators/cases/test_generators.rb
@@ -10,33 +10,33 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   destination File.expand_path('../tmp', __dir__)
   setup :prepare_destination
 
-  test 'Assert all files are properly created when no asset pipeline present' do
+  test 'Assert all files are properly created without sprockets and webpacker' do
     stub_configuration
     run_generator
     assert_file 'config/initializers/client_side_validations.rb'
     assert_file 'public/javascripts/rails.validations.js'
   end
 
-  test 'Assert all files are properly created when asset pipeline present and disabled' do
+  test 'Assert all files are properly created with sprockets' do
     stub_configuration
     configuration = {}
     configuration.stubs(:prefix).returns('/assets')
-    ClientSideValidations::Generators::CopyAssetsGenerator.stubs(:asset_pipeline_enabled?).returns false
+    ClientSideValidations::Generators::CopyAssetsGenerator.stubs(:sprockets?).returns true
     Rails.configuration.stubs(:assets).returns(configuration)
     run_generator
     assert_file 'config/initializers/client_side_validations.rb'
-    assert_file 'public/javascripts/rails.validations.js'
+    assert_no_file 'public/javascripts/rails.validations.js'
   end
 
-  test 'Assert all files are properly created when asset pipeline present and enabled' do
+  test 'Assert all files are properly created with webpacker' do
     stub_configuration
     configuration = {}
     configuration.stubs(:prefix).returns('/assets')
-    ClientSideValidations::Generators::CopyAssetsGenerator.stubs(:asset_pipeline_enabled?).returns true
+    ClientSideValidations::Generators::CopyAssetsGenerator.stubs(:webpacker?).returns true
     Rails.configuration.stubs(:assets).returns(configuration)
     run_generator
     assert_file 'config/initializers/client_side_validations.rb'
-    assert_no_file 'app/assets/javascripts/rails.validations.js'
+    assert_no_file 'public/javascripts/rails.validations.js'
   end
 
   def stub_configuration
@@ -49,30 +49,27 @@ class CopyAssetsGeneratorTest < Rails::Generators::TestCase
   destination File.expand_path('../tmp', __dir__)
   setup :prepare_destination
 
-  test 'Assert file is properly created when no asset pipeline present' do
+  test 'Assert file is properly created without sprockets and webpacker' do
     stub_configuration
     run_generator
     assert_file 'public/javascripts/rails.validations.js'
   end
 
-  test 'Assert file is properly created when asset pipeline present and disabled' do
+  test 'Assert file is properly created with sprockets' do
     stub_configuration
     configuration = {}
     configuration.stubs(:prefix).returns('/assets')
-    ClientSideValidations::Generators::CopyAssetsGenerator.stubs(:asset_pipeline_enabled?).returns false
-    Rails.configuration.stubs(:assets).returns(configuration)
-    run_generator
-    assert_file 'public/javascripts/rails.validations.js'
-  end
-
-  test 'Assert file is properly created when asset pipeline present and enabled' do
-    stub_configuration
-    configuration = {}
-    configuration.stubs(:prefix).returns('/assets')
-    ClientSideValidations::Generators::CopyAssetsGenerator.stubs(:asset_pipeline_enabled?).returns true
+    ClientSideValidations::Generators::CopyAssetsGenerator.stubs(:sprockets?).returns true
     Rails.configuration.stubs(:assets).returns(configuration)
     run_generator
     assert_file 'app/assets/javascripts/rails.validations.js'
+  end
+
+  test 'Assert file is properly created with webpacker' do
+    stub_configuration
+    ClientSideValidations::Generators::CopyAssetsGenerator.stubs(:webpacker?).returns true
+    run_generator
+    assert_file 'public/javascripts/rails.validations.js'
   end
 
   def stub_configuration


### PR DESCRIPTION
Generators were copying file when sprockets was not detected, even
if webpacker was present. This commit fixes the wrong behaviour.