### PR TITLE
React / Yup / Formik / GraphQL compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "homepage": "https://github.com/DavyJonesLocker/client_side_validations",
   "scripts": {
     "build": "standard --verbose && rollup -c",
-    "test": "test/javascript/run-qunit.js"
+    "test": "test/javascript/run-qunit.js",
+    "jest": "jest yup/*.test.js"
   },
   "devDependencies": {
     "@babel/core": "^7.9.6",
@@ -27,6 +28,7 @@
     "@rollup/plugin-babel": "^5.0.2",
     "@rollup/plugin-node-resolve": "^8.0.0",
     "chrome-launcher": "^0.13.2",
+    "jest": "^25.5.4",
     "puppeteer-core": "^3.1.0",
     "rollup": "^2.10.9",
     "rollup-plugin-copy": "^3.3.0",

--- a/yup/ClientSideValidations.js
+++ b/yup/ClientSideValidations.js
@@ -1,0 +1,257 @@
+const NUMBER_FORMAT = { separator: ".", delimiter: "," };
+const NUMERICALITY_DEFAULT = new RegExp(
+  "^[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?$"
+);
+const NUMERICALITY_ONLY_INTEGER = new RegExp("^[+-]?\\d+$");
+
+class ClientSideValidations {
+  absence(value = "", options = {}) {
+    if (!/^\s*$/.test(value)) {
+      return options.message;
+    }
+    return null;
+  }
+
+  presence(value = "", options = {}) {
+    if (/^\s*$/.test(value)) {
+      return options.message;
+    }
+    return null;
+  }
+
+  acceptance(value = true, options = {}) {
+    if (typeof value === "boolean") {
+      if (value !== true) {
+        return options.message;
+      }
+    }
+
+    let ref;
+
+    if (typeof value === "string") {
+      if (
+        value !==
+        (((ref = options.accept) != null ? ref.toString() : void 0) || "1")
+      ) {
+        return options.message;
+      }
+    }
+
+    return null;
+  }
+
+  format(value = "", options = {}) {
+    const message = this.presence(value, options);
+    if (message) {
+      if (options.allow_blank === true) {
+        return null;
+      }
+      return message;
+    }
+
+    if (
+      options.with &&
+      !new RegExp(options.with.source, options.with.options).test(value)
+    ) {
+      return options.message;
+    }
+
+    if (
+      options.without &&
+      new RegExp(options.without.source, options.without.options).test(value)
+    ) {
+      return options.message;
+    }
+
+    return null;
+  }
+
+  numericality(value = "", options = {}) {
+    if (
+      options.allow_blank === true &&
+      this.presence(value, { message: options.messages.numericality })
+    ) {
+      return null;
+    }
+
+    value = value
+      .trim()
+      .replace(new RegExp("\\" + NUMBER_FORMAT.separator, "g"), ".");
+
+    if (options.only_integer && !NUMERICALITY_ONLY_INTEGER.test(value)) {
+      return options.messages.only_integer;
+    }
+
+    if (!NUMERICALITY_DEFAULT.test(value)) {
+      return options.messages.numericality;
+    }
+
+    const NUMERICALITY_CHECKS = {
+      greater_than(a, b) {
+        return a > b;
+      },
+      greater_than_or_equal_to(a, b) {
+        return a >= b;
+      },
+      equal_to(a, b) {
+        return a === b;
+      },
+      less_than(a, b) {
+        return a < b;
+      },
+      less_than_or_equal_to(a, b) {
+        return a <= b;
+      },
+    };
+
+    for (var check in NUMERICALITY_CHECKS) {
+      const check_function = NUMERICALITY_CHECKS[check];
+      if (options[check] != null) {
+        const checkValue = (() => {
+          if (!isNaN(parseFloat(options[check])) && isFinite(options[check])) {
+            return options[check];
+          }
+        })();
+
+        if (checkValue == null || checkValue === "") {
+          return null;
+        }
+
+        if (!check_function(parseFloat(value), parseFloat(checkValue))) {
+          return options.messages[check];
+        }
+      }
+    }
+
+    if (options.odd && !(parseInt(value, 10) % 2)) {
+      return options.messages.odd;
+    }
+
+    if (options.even && parseInt(value, 10) % 2) {
+      return options.messages.even;
+    }
+
+    return null;
+  }
+
+  length(value = "", options = {}) {
+    const { length } = value;
+    const LENGTH_CHECKS = {
+      is(a, b) {
+        return a === b;
+      },
+      minimum(a, b) {
+        return a >= b;
+      },
+      maximum(a, b) {
+        return a <= b;
+      },
+    };
+    const blankOptions = {};
+    blankOptions.message = (() => {
+      if (options.is) {
+        return options.messages.is;
+      } else if (options.minimum) {
+        return options.messages.minimum;
+      }
+    })();
+
+    const message = this.presence(value, blankOptions);
+    if (message) {
+      if (options.allow_blank === true) {
+        return null;
+      }
+      return message;
+    }
+
+    for (let check in LENGTH_CHECKS) {
+      const check_function = LENGTH_CHECKS[check];
+      if (options[check]) {
+        if (!check_function(length, parseInt(options[check]))) {
+          return options.messages[check];
+        }
+      }
+    }
+
+    return null;
+  }
+
+  exclusion(value = "", options = {}) {
+    const message = this.presence(value, options);
+    if (message) {
+      if (options.allow_blank === true) {
+        return null;
+      }
+      return message;
+    }
+
+    if (options.in) {
+      let needle;
+      if (
+        ((needle = value),
+        Array.from(
+          Array.from(options.in).map((option) => option.toString())
+        ).includes(needle))
+      ) {
+        return options.message;
+      }
+    }
+
+    if (options.range) {
+      const lower = options.range[0];
+      const upper = options.range[1];
+      if (value >= lower && value <= upper) {
+        return options.message;
+      }
+    }
+
+    return null;
+  }
+
+  inclusion(value = "", options = {}) {
+    const message = this.presence(value, options);
+    if (message) {
+      if (options.allow_blank === true) {
+        return null;
+      }
+      return message;
+    }
+
+    if (options.in) {
+      let needle;
+      if (
+        ((needle = value),
+        Array.from(
+          Array.from(options.in).map((option) => option.toString())
+        ).includes(needle))
+      ) {
+        return null;
+      }
+      return options.message;
+    }
+
+    if (options.range) {
+      const lower = options.range[0];
+      const upper = options.range[1];
+      if (value >= lower && value <= upper) {
+        return null;
+      }
+      return options.message;
+    }
+  }
+
+  confirmation(value = "", options = { confirmation: "" }) {
+    if (value.toLowerCase() !== options.confirmation.toLowerCase()) {
+      return options.message;
+    }
+    return null;
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  uniqueness(value = "", options = {}) {
+    // Impossible to test locally, always return null
+    return null;
+  }
+}
+
+export default ClientSideValidations;

--- a/yup/model_validations_service.rb
+++ b/yup/model_validations_service.rb
@@ -1,0 +1,24 @@
+#
+# This module uses `client_side_validations` gem to extract
+# model validations, so we have the same goals and restrictions
+# that they have: https://github.com/DavyJonesLocker/client_side_validations
+#
+module ModelValidationsService
+
+  def self.get_validations(model_name)
+    model_class = Object.const_get(model_name)
+    validation_hash = model_class.new.client_side_validation_hash
+
+    validation_hash.map do |attr_name, validators|
+      {
+        attribute: attr_name.to_s.camelize(:lower),
+        validators: validators.map do |name, options|
+          {
+            name: name,
+            options: options
+          }
+        end
+      }
+    end
+  end
+end

--- a/yup/validateSchema.js
+++ b/yup/validateSchema.js
@@ -1,0 +1,45 @@
+import ClientSideValidations from "./ClientSideValidations";
+
+const validation = (value = "", validations = []) => {
+  const clientSideValidations = new ClientSideValidations();
+
+  // Save responses
+  const responses = [];
+
+  // Convert value to string
+  const strValue = typeof value === "number" ? `${value}` : value;
+
+  // Validate each option
+  validations.forEach(({ name, options }) => {
+    const parsedOptions = options.map((option) =>
+      typeof option === "string" ? JSON.parse(option) : option
+    );
+    parsedOptions.forEach((options) => {
+      const result = clientSideValidations[name](strValue, options) || null;
+      if (result) {
+        responses.push(result);
+      }
+    });
+  });
+
+  if (responses.length) {
+    // Format response string
+    let formattedResponse = "";
+    formattedResponse = "";
+    responses.forEach((response, i) => {
+      formattedResponse = i ? formattedResponse + ", " + response : response;
+    });
+    formattedResponse =
+      formattedResponse.charAt(0).toUpperCase() +
+      formattedResponse.slice(1) +
+      ".";
+
+    // Fail validation
+    return formattedResponse;
+  } else {
+    // Pass validation
+    return "";
+  }
+};
+
+export default validation;

--- a/yup/validateSchema.test.js
+++ b/yup/validateSchema.test.js
@@ -1,0 +1,610 @@
+import validateSchema from "./validateSchema";
+
+const message = "failed validation";
+const fail = "Failed validation.";
+const pass = "";
+
+describe("validation absence", () => {
+  const name = "absence";
+
+  const make = (value, options) =>
+    validateSchema(value, [{ name, options: [{ message, ...options }] }]);
+
+  it("when value is not empty", () => {
+    const value = "not empty";
+    const options = {};
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when value is only spaces", () => {
+    const value = "   ";
+    const options = {};
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when value is empty", () => {
+    const value = "";
+    const options = {};
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when value is null from non-selected multi-select element", () => {
+    const value = "";
+    const options = {};
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when value is not null from multi-select element", () => {
+    const value = "selected-option";
+    const options = {};
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when value is null from select element", () => {
+    const value = "";
+    const options = {};
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when value is not null from select element", () => {
+    const value = "selected-option";
+    const options = {};
+    expect(make(value, options)).toBe(fail);
+  });
+});
+
+describe("validation acceptance", () => {
+  const name = "acceptance";
+  const make = (value, options) =>
+    validateSchema(value, [{ name, options: [{ message, ...options }] }]);
+
+  it("when checkbox and checked", () => {
+    const value = true;
+    const options = {};
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when checkbox and not checked", () => {
+    const value = false;
+    const options = {};
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when text and value default of 1", () => {
+    const value = "1";
+    const options = {};
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when text and value 1 and accept value is 1", () => {
+    const value = "1";
+    const options = { accept: 1 };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when text and value empty", () => {
+    const value = "";
+    const options = {};
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when text and value 1 and accept value is 2", () => {
+    const value = "1";
+    const options = { accept: 2 };
+    expect(make(value, options)).toBe(fail);
+  });
+});
+
+describe("validation confirmation", () => {
+  const name = "confirmation";
+
+  const make = (value, options) =>
+    validateSchema(value, [{ name, options: [{ message, ...options }] }]);
+
+  it("when values match (case sensitive)", () => {
+    const value = "test";
+    const options = { confirmation: "test" };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when values do not match", () => {
+    const value = "test";
+    const options = { confirmation: "bad test" };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when values match (case insensitive)", () => {
+    const value = "tEsT";
+    const options = { confirmation: "test" };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when values contain special characters", () => {
+    const value = "te+st";
+    const options = { confirmation: "te+st" };
+    expect(make(value, options)).toBe(pass);
+  });
+});
+
+describe("validation exclusion", () => {
+  const name = "exclusion";
+
+  const make = (value, options) =>
+    validateSchema(value, [{ name, options: [{ message, ...options }] }]);
+
+  it("when value is not in the list", () => {
+    const value = "4";
+    const options = { in: [1, 2, 3] };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when value is not in the range", () => {
+    const value = "4";
+    const options = { range: [1, 3] };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when value is in the list", () => {
+    const value = "1";
+    const options = { in: [1, 2, 3] };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when value is in the range", () => {
+    const value = "1";
+    const options = { range: [1, 3] };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when allowing blank", () => {
+    const value = "";
+    const options = { in: [1, 2, 3], allow_blank: true };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when not allowing blank", () => {
+    const value = "";
+    const options = { in: [1, 2, 3] };
+    expect(make(value, options)).toBe(fail);
+  });
+});
+
+describe("validation format", () => {
+  const name = "format";
+
+  const make = (value, options) =>
+    validateSchema(value, [{ name, options: [{ message, ...options }] }]);
+
+  it("when matching format", () => {
+    const value = "123";
+    const options = { with: /\d+/ };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when not matching format", () => {
+    const value = "abc";
+    const options = { with: /\d+/ };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when allowing blank", () => {
+    const value = "";
+    const options = { with: /\d+/, allow_blank: true };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when not allowing blank", () => {
+    const value = "";
+    const options = { with: /\d+/ };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when using the without option and the Regex is matched", () => {
+    const value = "Rock";
+    const options = { without: /R/ };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when using the without option and the Regex is not matched", () => {
+    const value = "Lock";
+    const options = { without: /R/ };
+    expect(make(value, options)).toBe(pass);
+  });
+});
+
+describe("validation inclusion", () => {
+  const name = "inclusion";
+
+  const make = (value, options) =>
+    validateSchema(value, [{ name, options: [{ message, ...options }] }]);
+
+  it("when value is in the list", () => {
+    const value = "1";
+    const options = { in: [1, 2, 3] };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when value is in the range", () => {
+    const value = "1";
+    const options = { range: [1, 3] };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when value is not in the list", () => {
+    const value = "4";
+    const options = { in: [1, 2, 3] };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when value is not in the range", () => {
+    const value = "4";
+    const options = { range: [1, 3] };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when allowing blank", () => {
+    const value = "";
+    const options = { in: [1, 2, 3], allow_blank: true };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when not allowing blank", () => {
+    const value = "";
+    const options = { in: [1, 2, 3] };
+    expect(make(value, options)).toBe(fail);
+  });
+});
+
+describe("validation length", () => {
+  const name = "length";
+
+  const make = (value, options) =>
+    validateSchema(value, [{ name, options: [options] }]);
+
+  it("when allowed length is 3 and value length is 3", () => {
+    const value = "123";
+    const options = { messages: { is: message }, is: 3 };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when allowed length is 3 and value length is 4", () => {
+    const value = "1234";
+    const options = { messages: { is: message }, is: 3 };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when allowed length is 3 and value length is 2", () => {
+    const value = "12";
+    const options = { messages: { is: message }, is: 3 };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when allowing blank and allowed length is 3", () => {
+    const value = "";
+    const options = { messages: { is: message }, is: 3, allow_blank: true };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when allowing blank and minimum length is 3 and maximum length is 100", () => {
+    const value = "";
+    const options = {
+      messages: {
+        minimum: "failed minimum validation",
+        maximum: "failed maximum validation",
+      },
+      minimum: 3,
+      maximum: 100,
+      allow_blank: true,
+    };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when not allowing blank and allowed length is 3", () => {
+    const value = "";
+    const options = { messages: { is: message }, is: 3 };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when allowed length minimum is 3 and value length is 3", () => {
+    const value = "123";
+    const options = { messages: { is: message }, is: 3 };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when allowed length minimum is 3 and value length is 2", () => {
+    const value = "12";
+    const options = { messages: { minimum: message }, minimum: 3 };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when allowed length maximum is 3 and value length is 3", () => {
+    const value = "123";
+    const options = { messages: { is: message }, is: 3 };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when allowed length maximum is 3 and value length is 4", () => {
+    const value = "1234";
+    const options = { messages: { maximum: message }, maximum: 3 };
+    expect(make(value, options)).toBe(fail);
+  });
+});
+
+describe("validation numericality", () => {
+  const name = "numericality";
+
+  const make = (value, options) =>
+    validateSchema(value, [{ name, options: [options] }]);
+
+  it("when value is a number", () => {
+    const value = "123";
+    const options = { messages: { numericality: message } };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when value is a decimal number", () => {
+    const value = "123.456";
+    const options = { messages: { numericality: message } };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when value is not a number", () => {
+    const value = "abc123";
+    const options = { messages: { numericality: message } };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when no value", () => {
+    const value = "";
+    const options = { messages: { numericality: message } };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when no value and allowing blank", () => {
+    const value = "";
+    const options = { messages: { numericality: message }, allow_blank: true };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when bad value and allowing blank", () => {
+    const value = "abc123";
+    const options = { messages: { numericality: message }, allow_blank: true };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when only allowing integers and allowing blank", () => {
+    const value = "";
+    const options = {
+      messages: { only_integer: message, numericality: message },
+      only_integer: true,
+      allow_blank: true,
+    };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when only allowing integers and value is integer", () => {
+    const value = "123";
+    const options = {
+      messages: { only_integer: message, numericality: message },
+      only_integer: true,
+    };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when only allowing integers and value is integer with whitespace", () => {
+    const value = " 123 ";
+    const options = {
+      messages: { only_integer: message, numericality: message },
+      only_integer: true,
+    };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when only allowing integers and value has a positive sign", () => {
+    const value = "+23";
+    const options = {
+      messages: { only_integer: message, numericality: message },
+      only_integer: true,
+    };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when only allowing integers and value has a negative sign", () => {
+    const value = "-23";
+    const options = {
+      messages: { only_integer: message, numericality: message },
+      only_integer: true,
+    };
+    expect(make(value, options)).toBe(pass);
+  });
+  it("when only allowing integers and value is not integer", () => {
+    const value = "123.456";
+    const options = {
+      messages: { only_integer: message, numericality: message },
+      only_integer: true,
+    };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when only allowing integers and value has a delimiter", () => {
+    const value = "10,000";
+    const options = {
+      messages: { only_integer: message, numericality: message },
+      only_integer: true,
+    };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when only allowing values greater than 10 and value is greater than 10", () => {
+    const value = "11";
+    const options = {
+      messages: { greater_than: message, numericality: message },
+      greater_than: 10,
+    };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when only allowing values greater than 10 and value is 10", () => {
+    const value = "10";
+    const options = {
+      messages: { greater_than: message, numericality: message },
+      greater_than: 10,
+    };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when only allowing values greater than or equal to 10 and value is 10", () => {
+    const value = "10";
+    const options = {
+      messages: { greater_than_or_equal_to: message, numericality: message },
+      greater_than_or_equal_to: 10,
+    };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when only allowing values greater than or equal to 10 and value is 9", () => {
+    const value = "9";
+    const options = {
+      messages: { greater_than_or_equal_to: message, numericality: message },
+      greater_than_or_equal_to: 10,
+    };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when only allowing values less than 10 and value is less than 10", () => {
+    const value = "9";
+    const options = {
+      messages: { less_than: message, numericality: message },
+      less_than: 10,
+    };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when only allowing values less than 10 and value is 10", () => {
+    const value = "10";
+    const options = {
+      messages: { less_than: message, numericality: message },
+      less_than: 10,
+    };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when only allowing values less than or equal to 10 and value is 10", () => {
+    const value = "10";
+    const options = {
+      messages: { less_than_or_equal_to: message, numericality: message },
+      less_than_or_equal_to: 10,
+    };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when only allowing values less than or equal to 10 and value is 11", () => {
+    const value = "11";
+    const options = {
+      messages: { less_than_or_equal_to: message, numericality: message },
+      less_than_or_equal_to: 10,
+    };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when only allowing values equal to 10 and value is 10", () => {
+    const value = "10";
+    const options = {
+      messages: { equal_to: message, numericality: message },
+      equal_to: 10,
+    };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when only allowing values equal to 10 and value is 11", () => {
+    const value = "11";
+    const options = {
+      messages: { equal_to: message, numericality: message },
+      equal_to: 10,
+    };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when only allowing value equal to 0 and value is 1", () => {
+    const value = "1";
+    const options = {
+      messages: { equal_to: message, numericality: message },
+      equal_to: 0,
+    };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when only allowing odd values and the value is odd", () => {
+    const value = "11";
+    const options = {
+      messages: { odd: message, numericality: message },
+      odd: true,
+    };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when only allowing odd values and the value is even", () => {
+    const value = "10";
+    const options = {
+      messages: { odd: message, numericality: message },
+      odd: true,
+    };
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when only allowing even values and the value is even", () => {
+    const value = "10";
+    const options = {
+      messages: { even: message, numericality: message },
+      even: true,
+    };
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when only allowing even values and the value is odd", () => {
+    const value = "11";
+    const options = {
+      messages: { even: message, numericality: message },
+      even: true,
+    };
+    expect(make(value, options)).toBe(fail);
+  });
+});
+
+describe("validation presence", () => {
+  const name = "presence";
+
+  const make = (value, options) =>
+    validateSchema(value, [{ name, options: [{ message, ...options }] }]);
+
+  it("when value is not empty", () => {
+    const value = "not empty";
+    const options = {};
+    expect(make(value, options)).toBe(pass);
+  });
+
+  it("when value is empty", () => {
+    const value = "";
+    const options = {};
+    expect(make(value, options)).toBe(fail);
+  });
+
+  it("when value is null from non-selected multi-select element", () => {
+    const value = "";
+    const options = {};
+    expect(make(value, options)).toBe(fail);
+  });
+});
+
+describe("validation uniqueness", () => {
+  const name = "uniqueness";
+
+  const make = (value, options) =>
+    validateSchema(value, [{ name, options: [{ message, ...options }] }]);
+
+  it("uniqueness cannot be tested", () => {
+    const value = true;
+    const options = {};
+    expect(make(value, options)).toBe(pass);
+  });
+});

--- a/yup/validationSchema.js
+++ b/yup/validationSchema.js
@@ -1,0 +1,60 @@
+import validateSchema from "./validateSchema";
+import { set } from "lodash-es";
+
+export default function validationSchema(formObject = {}, tests = []) {
+  let errors = {};
+
+  Object.keys(formObject).forEach((formObjectKey) => {
+    const formObjectValue = formObject[formObjectKey];
+
+    // If the value is an array
+    if (Array.isArray(formObjectValue)) {
+      // Loop over array
+      formObjectValue.forEach((childObject, i) => {
+        // Loop over each key in the childObject
+        Object.keys(childObject).forEach((childObjectKey) => {
+          const childObjectValue = childObject[childObjectKey];
+          // Loop through tests array
+          tests.forEach((test) => {
+            try {
+              // If the test attribute matches the childObjectKey...
+              if (test.attribute === childObjectKey) {
+                // Perform validation on childObjectValue
+                const result = validateSchema(
+                  childObjectValue,
+                  test.validators
+                );
+                if (result !== "") {
+                  set(errors, [formObjectKey, i, childObjectKey], result);
+                }
+              }
+            } catch (err) {
+              console.log(
+                `Validation error in ${formObjectKey}[${i}].${childObjectKey}: ${childObjectValue}`,
+                err
+              );
+            }
+          });
+        });
+      });
+    } else {
+      tests.forEach((test) => {
+        try {
+          if (test.attribute === formObjectKey) {
+            const result = validateSchema(formObjectValue, test.validators);
+            if (result !== "") {
+              errors[formObjectKey] = result;
+            }
+          }
+        } catch (err) {
+          console.log(
+            `Validation error in ${formObjectKey}: ${formObjectValue}`,
+            err
+          );
+        }
+      });
+    }
+  });
+
+  return errors;
+}


### PR DESCRIPTION
Please forgive this giant mess and info dump that is incompatible with your actual repo, and allow me to explain...

We use ClientSideValidations on the back-end in Rails, and we have used it on the front-end for years with UJS/jQuery. Thank you for the hard work, you made our lives easier.

Recently we've switched over to using React for some of the more complex forms, we found a form library called Formik that was helpful. They have a front-end validation built in, but this would involve needing to re-write all our model validations for their recommended API, called Yup.

Instead, we made a little file in our Rails back-end that translations your ClientSideValidations to that API/Yup format it expects, and send that as JSON over the wire.

It works well for using ClientSideValidations back-end with a React/Formik/Yup/whatever front-end. 

Not to let the code go to waste, I am basically dumping it from our repo to you in this PR, in the hopes that you could somehow use this to accommodate newer Rails users who use Webpacker gem and/or some combination of a front-end framework and would like to use it with ClientSideValidations for automatic validationScheme generation from the server based on the model.

Hope this makes sense, feel free to close this PR if you find this unusable. Thank you for your efforts over the years.