### PR TITLE
Fix tests for Rails 7.0

### DIFF
--- a/test/action_view/cases/helper.rb
+++ b/test/action_view/cases/helper.rb
@@ -71,8 +71,21 @@ module ActionViewTestSetup
     super
   end
 
+  def autocomplete_attribute
+    @autocomplete_attribute ||=
+      if hidden_field_tag(:test).include?('autocomplete')
+        'autocomplete="off"'
+      else
+        ''
+      end
+  end
+
   def hidden_input_for_select(name)
-    %(<input name="#{name}" type="hidden" value="" />)
+    %(<input name="#{name}" type="hidden" value="" #{autocomplete_attribute} />)
+  end
+
+  def hidden_input_for_checkbox(name)
+    %(<input name="#{name}" type="hidden" value="0" #{autocomplete_attribute} />)
   end
 
   def setup
@@ -128,7 +141,7 @@ module ActionViewTestSetup
 
     txt << %(<input name="utf8" type="hidden" value="&#x2713;" />) if default_enforce_utf8
 
-    txt << %(<input type="hidden" name="_method" value="#{method}" />) if method
+    txt << %(<input type="hidden" name="_method" value="#{method}" #{autocomplete_attribute} />) if method
 
     txt
   end
@@ -138,6 +151,7 @@ module ActionViewTestSetup
 
     txt << %( name="#{custom_name}") if custom_name
     txt << %( type="#{type}") if type
+    txt << %( #{autocomplete_attribute}) if %w[hidden].include?(type)
     txt << %( value="#{value}") if value
     txt << %( multiple="multiple") if multiple
     txt << %( name="#{name}") if name

--- a/test/action_view/cases/test_legacy_form_for_helpers.rb
+++ b/test/action_view/cases/test_legacy_form_for_helpers.rb
@@ -47,7 +47,7 @@ module ClientSideValidations
       end
 
       expected = whole_form_for('/posts', 'new_post', 'new_post') do
-        %(<input name="post[cost]" type="hidden" value="0" />) +
+        hidden_input_for_checkbox('post[cost]') +
           form_field('input', id: 'post_cost', name: 'post[cost]', type: 'checkbox', value: '1')
       end
       assert_dom_equal expected, output_buffer

--- a/test/action_view/cases/test_legacy_form_with_helpers.rb
+++ b/test/action_view/cases/test_legacy_form_with_helpers.rb
@@ -48,7 +48,7 @@ if ::ActionView::Helpers::FormHelper.method_defined?(:form_with)
         end
 
         expected = whole_form_with('/posts') do
-          %(<input name="post[cost]" type="hidden" value="0" />) +
+          hidden_input_for_checkbox('post[cost]') +
             form_field('input', name: 'post[cost]', id: conditional_id('post_cost'), type: 'checkbox', value: '1')
         end
         assert_dom_equal expected, output_buffer


### PR DESCRIPTION
Rails edge adds `autocomplete="off"` to some hidden fields