### PR TITLE
Fix SimpleCov dependency version range

### DIFF
--- a/client_side_validations.gemspec
+++ b/client_side_validations.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.14'
   spec.add_development_dependency 'mocha', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'simplecov', '>= 0.18.5', '< 0.22'
+  spec.add_development_dependency 'simplecov', '~> 0.21.2'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8.0'
   spec.add_development_dependency 'sqlite3', '~> 1.4'
 


### PR DESCRIPTION
0.21.2 supports Ruby 2.5