### PR TITLE
Ensure html options include http method

### DIFF
--- a/lib/client_side_validations/action_view/form_helper.rb
+++ b/lib/client_side_validations/action_view/form_helper.rb
@@ -38,6 +38,7 @@ module ClientSideValidations
 
         def apply_csv_form_for_options!(record, object, options)
           options[:html][:validate] = true if options[:validate]
+          options[:html][:method] ||= options[:method]
 
           if method(:apply_form_for_options!).arity == 2
             apply_form_for_options! object, options

--- a/test/action_view/cases/test_form_for_helpers.rb
+++ b/test/action_view/cases/test_form_for_helpers.rb
@@ -42,6 +42,19 @@ module ClientSideValidations
       end
     end
 
+    def test_http_method
+      form_for(@post, validate: true, method: :patch) do |f|
+        concat f.text_area(:cost)
+      end
+
+      validators = { 'post[cost]' => { presence: [{ message: "can't be blank" }] } }
+      expected = whole_form_for('/posts', 'new_post', 'new_post', validators: validators) do
+        form_field('input', name: '_method', type: 'hidden', value: 'patch') +
+          form_field('textarea', id: 'post_cost', name: 'post[cost]', tag_content: "\n")
+      end
+      assert_dom_equal expected, output_buffer
+    end
+
     def test_text_area
       form_for(@post, validate: true) do |f|
         concat f.text_area(:cost)


### PR DESCRIPTION
This change is not needed in Rails 7 but on older versions

Fix: #867
Ref: rails/rails#43421