### PR TITLE
Add explicit permissions to workflows

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Tests

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   rubocop:
     name: Rubocop

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Tests

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -74,6 +74,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
+        rubygems: latest
         bundler-cache: true
     - name: Run tests
       run: bundle exec rake test:ruby


### PR DESCRIPTION
Workflows run with extended set of permissions by default. By specifying any permission explicitly, all others are set to none.

Ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions