### PR TITLE
Fix spec for js_regex 3.10.0

### DIFF
--- a/test/core_ext/cases/test_core_ext.rb
+++ b/test/core_ext/cases/test_core_ext.rb
@@ -97,7 +97,7 @@ class CoreExtTest < MiniTest::Test
   def test_extended_mode_regexp_with_escaped_whitespace_as_json
     # regression test for issue #625
     test_regexp = /    [\ a]\    /x
-    expected_regexp = { source: '[\\x20a] ', options: '' }
+    expected_regexp = { source: '[ a] ', options: '' }
 
     assert_equal expected_regexp, test_regexp.as_json
   end


### PR DESCRIPTION
hi!

i've just released a version of [js_regex](https://github.com/jaynetics/js_regex) with a fix that makes the spec below red.

the spec (probably written by myself at some point 😊), was expecting an escape sequence were no escape sequence is necessary.

there are no changes that affect functionality.

cheers
j.