### PR TITLE
Fallback on "invalid" with missing translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 22.1.1 / 2023-10-08
+
+* [BUGFIX] Fix a bug with missing translations ([#920](https://github.com/DavyJonesLocker/client_side_validations/issues/920))
+
 ## 22.1.0 / 2023-10-05
 
 * [FEATURE] Rails 7.1 compatibility

--- a/lib/client_side_validations/version.rb
+++ b/lib/client_side_validations/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ClientSideValidations
-  VERSION = '22.1.0'
+  VERSION = '22.1.1'
 end

--- a/test/active_model/cases/test_validations.rb
+++ b/test/active_model/cases/test_validations.rb
@@ -484,6 +484,20 @@ module ActiveModel
       assert_equal expected_hash, person.client_side_validation_hash
     end
 
+    def test_missing_translation
+      person = new_person do |p|
+        p.validates :first_name, custom_validation: true
+      end
+
+      expected_hash = {
+        first_name: {
+          custom_validation: [{ message: 'is invalid' }]
+        }
+      }
+
+      assert_equal expected_hash, person.client_side_validation_hash
+    end
+
     def test_ignored_procs_validators
       person = new_person do |p|
         p.validates :first_name, format: proc { |o| o.matcher }

--- a/test/base_helper.rb
+++ b/test/base_helper.rb
@@ -50,4 +50,12 @@ end
 
 Rails.application.initialize!
 
+class CustomValidationValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    record.errors.add(attribute, :invalid, **options)
+  end
+end
+
 module ClientSideValidations; end


### PR DESCRIPTION
When `config.i18n.raise_on_missing_translations` is enabled, Rails 7.1 raises on missing translation error when validation messages are not translated, which is a new behavior causing CSV to fail

For unsupported validations, like `comparison`, and custom validations, like `timeliness`, CSV attempts to create a message for a key that is not present.

This commit standardizes the behavior and fallbacks on "invalid" when a translation is not found, which is supposed to be the desired behavior for this use case

Close #920