### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,12 +20,6 @@ jobs:
         channel: ['stable']
 
         include:
-          - ruby-version: '2.7'
-            gemfile: rails_edge
-            channel: 'experimental'
-          - ruby-version: '3.0'
-            gemfile: rails_edge
-            channel: 'experimental'
           - ruby-version: '3.1'
             gemfile: rails_edge
             channel: 'experimental'


### PR DESCRIPTION
Rails edge now requires Ruby >= 3.1

Ref: https://github.com/DavyJonesLocker/client_side_validations/actions/runs/7371474862/job/20058903253