### PR TITLE
Fix package.json engines and required Node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
   "main": "dist/client-side-validations.js",
   "module": "dist/client-side-validations.esm.js",
   "engines": {
-    "node": ">= 18.0",
-    "pnpm": "^9.12.1"
+    "node": ">= 18.12"
   },
   "packageManager": "pnpm@^9.12.1",
   "browserslist": [


### PR DESCRIPTION
Including "pnpm" in the engines field of your package.json for a library is generally not recommended, even if you use it for building the library. The engines field is typically used to specify runtime environments (such as Node.js versions) that are required to run the library, not the tools used to build or develop it. Most developers expect the engines field to list only the runtime requirements, not development tools like package managers.