### PR TITLE
Use dataset to access CSV Settings

### DIFF
--- a/dist/client-side-validations.esm.js
+++ b/dist/client-side-validations.esm.js
@@ -123,7 +123,7 @@ var ClientSideValidations = {
     form: function form(_form2) {
       var $form = jQuery(_form2);
       _form2.ClientSideValidations = {
-        settings: $form.data('clientSideValidations'),
+        settings: JSON.parse(_form2.dataset.clientSideValidations),
         addError: function addError($element, message) {
           return ClientSideValidations.formBuilders[_form2.ClientSideValidations.settings.html_settings.type].add($element, _form2.ClientSideValidations.settings.html_settings, message);
         },

--- a/dist/client-side-validations.js
+++ b/dist/client-side-validations.js
@@ -127,7 +127,7 @@
       form: function form(_form2) {
         var $form = jQuery(_form2);
         _form2.ClientSideValidations = {
-          settings: $form.data('clientSideValidations'),
+          settings: JSON.parse(_form2.dataset.clientSideValidations),
           addError: function addError($element, message) {
             return ClientSideValidations.formBuilders[_form2.ClientSideValidations.settings.html_settings.type].add($element, _form2.ClientSideValidations.settings.html_settings, message);
           },

--- a/src/core.js
+++ b/src/core.js
@@ -84,7 +84,7 @@ const ClientSideValidations = {
       const $form = jQuery(form)
 
       form.ClientSideValidations = {
-        settings: $form.data('clientSideValidations'),
+        settings: JSON.parse(form.dataset.clientSideValidations),
         addError: ($element, message) => ClientSideValidations
           .formBuilders[form.ClientSideValidations.settings.html_settings.type]
           .add($element, form.ClientSideValidations.settings.html_settings, message),

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -127,7 +127,7 @@
       form: function form(_form2) {
         var $form = jQuery(_form2);
         _form2.ClientSideValidations = {
-          settings: $form.data('clientSideValidations'),
+          settings: JSON.parse(_form2.dataset.clientSideValidations),
           addError: function addError($element, message) {
             return ClientSideValidations.formBuilders[_form2.ClientSideValidations.settings.html_settings.type].add($element, _form2.ClientSideValidations.settings.html_settings, message);
           },


### PR DESCRIPTION
According to jQuery's data implementation, this should be a backward-compatible change

Ref: 
- https://github.com/jquery/jquery/blob/f79d5f1a337528940ab7029d4f8bbba72326f269/src/data.js#L42-L44
- https://api.jquery.com/data/#data-html5