### PR TITLE
Remove jQuery from the JavaScript runtime

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,7 +32,7 @@ _Tell us what happens instead_
 - [ ] I confirm that my browser's development console output does not contain errors
 
 ### Additional JavaScript Libraries*
-_If your issue depends on other JavaScript libraries, please list them here. E.g: *Bootstrap Modal v3.3.7, jQuery UI Datepicker 1.12.4*._
+_If your issue depends on other JavaScript libraries, please list them here. E.g: *Bootstrap Modal v3.3.7, Stimulus 3.2.2*._
 
 ### Repository demostrating the issue
 Debugging CSV issues is a time consuming task. If you want to speed up things, please

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 24.0.0 / 2026-04-19
+* [FEATURE] Breaking change: Remove the jQuery runtime dependency and the old jQuery plugin aliases from the published JavaScript assets
+* [FEATURE] Breaking change: Public JavaScript APIs now work with native DOM elements and DOM collections instead of jQuery-wrapped objects
+* [ENHANCEMENT] Use native browser events and event listeners throughout the runtime and test harness
+
 ## 23.1.0 / 2026-01-27
 
 * [FEATURE] Add jQuery 4.0.0 compatibility

--- a/README.md
+++ b/README.md
@@ -56,11 +56,10 @@ config/initializers/client_side_validations.rb
 
 Instructions depend on your technology stack.
 
-Please note that CSV depends on jQuery >= 3.7.1 (jQuery slim is fine).
+ClientSideValidations no longer depends on jQuery.
+If you previously installed `jquery-rails`, `jquery_ujs`, or custom jQuery startup code only for ClientSideValidations, you can remove that integration when upgrading to 24.x.
 
 ####  When using Webpacker ####
-
-Make sure that you are requiring jQuery.
 
 Add the following package:
 
@@ -92,26 +91,7 @@ detect `window.Turbolinks` and attach its event handlers.
 
 ####  When using Sprockets ####
 
-Since ClientSideValidations can also be used via webpacker, it does not require
-by default `jquery-rails` gem.
-
-Make sure that `jquery-rails` is part of your bundled gems and `application.js`,
-otherwise add:
-
-```ruby
-gem 'jquery-rails'
-```
-
-to your `Gemfile`, run `bundle`, and add
-
-```js
-//= require jquery
-```
-
-to your `app/assets/javascripts/application.js` file.
-
-Then, add the following to your `app/assets/javascripts/application.js` file
-after `//= require jquery`.
+Add the following to your `app/assets/javascripts/application.js` file:
 
 ```js
 //= require rails.validations
@@ -128,6 +108,60 @@ rails g client_side_validations:copy_assets
 ```
 
 Note: If you run `copy_assets`, you will need to run it again each time you update this project.
+
+## Migration Guide ##
+
+### 24.x Breaking Changes ###
+
+If you are upgrading to 24.x, update your integration code to use the `ClientSideValidations` object directly.
+
+The old jQuery plugin methods are removed. Use the DOM-first public API instead:
+
+```js
+ClientSideValidations.enable(form)
+ClientSideValidations.validate(form)
+ClientSideValidations.isValid(form, validators)
+ClientSideValidations.disable(form)
+ClientSideValidations.reset(form)
+```
+
+These methods accept native DOM elements and DOM collections. They do not accept jQuery objects or CSS selector strings.
+
+Custom validators, form builders, and callbacks now receive native DOM nodes instead of jQuery wrappers. Update any custom code to use DOM APIs such as `.value`, `.form`, `.closest()`, and `querySelector()`.
+Local validators are called as `(element, options)`. Form callbacks receive `(form, eventData)`, and element callbacks receive either `(element, message, callback)` or `(element, callback)` depending on the event.
+
+All runtime-owned validation state attributes are now namespaced under `csv`. If you read or write these attributes in custom selectors, callbacks, or validators, update them to the scoped names:
+
+```text
+data-changed => data-csv-changed
+data-valid => data-csv-valid
+data-validate => data-csv-validate
+data-not-locally-unique => data-csv-not-locally-unique
+```
+
+The matching dataset properties are `element.dataset.csvChanged`, `element.dataset.csvValid`, `element.dataset.csvValidate`, and `element.dataset.csvNotLocallyUnique`. `csvChanged` is stored as the string values `'true'` and `'false'`.
+
+**jQuery namespaced events are removed.** Events are now plain native DOM custom events. If your application listens to or unbinds events using jQuery-style namespacing, you must update those calls.
+
+Before:
+
+```js
+$(form).on('form:validate:before.ClientSideValidations', handler)
+$(input).off('.ClientSideValidations')
+```
+
+After:
+
+```js
+form.addEventListener('form:validate:before', handler)
+// store and pass the handler reference to removeEventListener when unbinding
+```
+
+The full list of native events dispatched by ClientSideValidations: `form:validate:before`, `form:validate:after`, `form:validate:pass`, `form:validate:fail`, `element:validate:before`, `element:validate:after`, `element:validate:pass`, `element:validate:fail`.
+
+If you are upgrading from a version older than 23.0.0, the `data-csv-*` renaming above is required for any custom code that still reads or writes the old attribute names. If you are already on 23.x, the new 24.x upgrade step is to update any local uniqueness integrations that still reference `data-not-locally-unique` or `element.dataset.notLocallyUnique`.
+
+If your application vendors the compiled asset with `rails g client_side_validations:copy_assets`, run that generator again after upgrading so your copied asset matches the current jQuery-free bundle.
 
 ## Initializer ##
 
@@ -324,11 +358,11 @@ If you need to change the markup of how the errors are rendered you can modify t
 
 ```js
 window.ClientSideValidations.formBuilders['ActionView::Helpers::FormBuilder'] = {
-  add: function($element, settings, message) {
+  add: function(element, settings, message) {
     // custom add code here
   },
 
-  remove: function($element, settings) {
+  remove: function(element, settings) {
     // custom remove code here
   }
 }
@@ -376,14 +410,14 @@ en:
 Finally we need to add a client side validator. This can be done by hooking into the `ClientSideValidations.validator` object. Create a new file `app/assets/javascripts/rails.validations.customValidators.js`
 
 ```js
-// The validator variable is a JSON Object
-// The selector variable is a jQuery Object
-window.ClientSideValidations.validators.local['email'] = function($element, options) {
+// The options variable is a JSON Object
+// The element variable is a DOM element
+window.ClientSideValidations.validators.local.email = function (element, options) {
   // Your validator code goes in here
-  if (!/^([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})$/i.test($element.val())) {
+  if (!/^([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})$/i.test(element.value)) {
     // When the value fails to pass validation you need to return the error message.
     // It can be derived from validator.message
-    return options.message;
+    return options.message
   }
 }
 ```
@@ -408,7 +442,7 @@ There are many reasons why you might want to enable, disable, or even completely
 If you have rendered a new form via AJAX into your page you will need to enable that form for validation:
 
 ```js
-$(new_form).enableClientSideValidations();
+ClientSideValidations.enable(newForm)
 ```
 
 You should attach this to an event that is fired when the new HTML renders.
@@ -416,7 +450,7 @@ You should attach this to an event that is fired when the new HTML renders.
 You can use the same function if you introduce new inputs to an existing form:
 
 ```js
-$(new_input).enableClientSideValidations();
+ClientSideValidations.enable(newInput)
 ```
 
 ### Disabling ###
@@ -424,7 +458,7 @@ $(new_input).enableClientSideValidations();
 If you wish to turn off validations entirely on a form:
 
 ```js
-$(form).disableClientSideValidations();
+ClientSideValidations.disable(form)
 ```
 
 ### Resetting ###
@@ -432,44 +466,54 @@ $(form).disableClientSideValidations();
 You can reset the current state of the validations, clear all error messages, and reattach clean event handlers:
 
 ```js
-$(form).resetClientSideValidations();
+ClientSideValidations.reset(form)
 ```
 
 ## Callbacks ##
 
 `ClientSideValidations` will run callbacks based upon the state of the element or form. The following callbacks are supported:
 
-* `ClientSideValidations.callbacks.element.after($element, eventData)`
-* `ClientSideValidations.callbacks.element.before($element, eventData)`
-* `ClientSideValidations.callbacks.element.fail($element, message, callback, eventData)`
-* `ClientSideValidations.callbacks.element.pass($element, callback, eventData)`
-* `ClientSideValidations.callbacks.form.after($form, eventData)`
-* `ClientSideValidations.callbacks.form.before($form, eventData)`
-* `ClientSideValidations.callbacks.form.fail($form, eventData)`
-* `ClientSideValidations.callbacks.form.pass($form, eventData)`
+* `ClientSideValidations.callbacks.element.after(element, eventData)`
+* `ClientSideValidations.callbacks.element.before(element, eventData)`
+* `ClientSideValidations.callbacks.element.fail(element, message, callback, eventData)`
+* `ClientSideValidations.callbacks.element.pass(element, callback, eventData)`
+* `ClientSideValidations.callbacks.form.after(form, eventData)`
+* `ClientSideValidations.callbacks.form.before(form, eventData)`
+* `ClientSideValidations.callbacks.form.fail(form, eventData)`
+* `ClientSideValidations.callbacks.form.pass(form, eventData)`
 
 The names of the callbacks should be pretty straight forward. For example, `ClientSideValidations.callbacks.form.fail` will be called if a form failed to validate. And `ClientSideValidations.callbacks.element.before` will be called before that particular element's validations are run.
 
-All element callbacks will receive the element in a jQuery object as the first parameter and the eventData object as the second parameter. `ClientSideValidations.callbacks.element.fail()` will receive the message of the failed validation as the second parameter, the callback for adding the error fields as the third and the eventData object as the third. `ClientSideValidations.elementValidatePass()` will receive the callback for removing the error fields. The error field callbacks must be run in your custom callback in some fashion. (either after a blocking event or as a callback for another event, such as an animation)
+All element callbacks receive the DOM element as the first parameter and the native event object as the second parameter. `ClientSideValidations.callbacks.element.fail()` receives the failed message as the second parameter, the callback for adding error fields as the third parameter, and the eventData object as the fourth parameter. `ClientSideValidations.callbacks.element.pass()` receives the callback for removing the error fields as the second parameter. The error field callbacks must still be invoked by your custom callback.
 
-All form callbacks will receive the form in a jQuery object as the first parameter and the eventData object as the second parameter.
+All form callbacks receive the DOM form element as the first parameter and the native event object as the second parameter.
 
-Here is an example callback for sliding out the error message when the validation fails then sliding it back in when the validation passes:
+Here is an example callback that animates the error message when validation fails:
 
 ``` javascript
-// You will need to require 'jquery-ui' for this to work
-window.ClientSideValidations.callbacks.element.fail = function($element, message, callback) {
+window.ClientSideValidations.callbacks.element.fail = function (element, message, callback) {
   callback()
 
-  if ($element.data('csvValid') !== false) {
-    $element.parent().find('.message').hide().show('slide', { direction: 'left', easing: 'easeOutBounce' }, 500)
+  var messageElement = element.parentElement.querySelector('.message')
+
+  if (messageElement) {
+    if (typeof messageElement.animate === 'function') {
+      messageElement.animate(
+        [
+          { opacity: 0, transform: 'translateX(-8px)' },
+          { opacity: 1, transform: 'translateX(0)' }
+        ],
+        { duration: 250, easing: 'ease-out', fill: 'both' }
+      )
+    } else {
+      messageElement.style.opacity = '1'
+      messageElement.style.transform = 'translateX(0)'
+    }
   }
 }
 
-window.ClientSideValidations.callbacks.element.pass = function($element, callback) {
-  // Take note how we're passing the callback to the hide()
-  // method so it is run after the animation is complete.
-  $element.parent().find('.message').hide('slide', { direction: 'left' }, 500, callback)
+window.ClientSideValidations.callbacks.element.pass = function (element, callback) {
+  callback()
 }
 ```
 
@@ -478,11 +522,8 @@ window.ClientSideValidations.callbacks.element.pass = function($element, callbac
   background-color: red;
   border-bottom-right-radius: 5px 5px;
   border-top-right-radius: 5px 5px;
+  display: inline-block;
   padding: 2px 5px;
-}
-
-div.field_with_errors div.ui-effects-wrapper {
-  display: inline-block !important;
 }
 ```
 
@@ -506,22 +547,21 @@ By default, ClientSideValidations will automatically validate the form.
 If for some reason you would like to manually validate the form (for example you're working with a multi-step form), you can use the following approach:
 
 ```js
-$input     = $('#myInputField');
-$form      = $($input[0].form);
-validators = $form[0].ClientSideValidations.settings.validators;
+const input = document.getElementById('myInputField')
+const form = input.form
+const validators = form.ClientSideValidations.settings.validators
 
 // Validate a single field
-// It might not work for multiple inputs selected at once by `$input`
-$input.isValid(validators);
+ClientSideValidations.isValid(input, validators)
 
 // Validate the whole form
-$form.isValid(validators);
+ClientSideValidations.isValid(form, validators)
 ```
 
 To manually validate a single field, you may also trigger a focusout event:
 
 ```js
-$('#myInputField').trigger('focusout');
+input.dispatchEvent(new Event('focusout', { bubbles: true }))
 ```
 
 ## Authors ##

--- a/dist/client-side-validations.esm.js
+++ b/dist/client-side-validations.esm.js
@@ -1,10 +1,44 @@
 /*!
- * Client Side Validations JS - v23.1.0 (https://github.com/DavyJonesLocker/client_side_validations)
+ * Client Side Validations JS - v24.0.0 (https://github.com/DavyJonesLocker/client_side_validations)
  * Copyright (c) 2026 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */
 
-import jQuery from 'jquery';
+const boundEventListeners = new WeakMap();
+const addBoundEventListener = (element, eventName, listener) => {
+  element.addEventListener(eventName, listener);
+  const listeners = boundEventListeners.get(element) || [];
+  listeners.push({
+    eventName,
+    listener
+  });
+  boundEventListeners.set(element, listeners);
+};
+const bindElementEvents = (element, eventsToBind) => {
+  for (const eventName in eventsToBind) {
+    addBoundEventListener(element, eventName, eventsToBind[eventName]);
+  }
+};
+const clearBoundEventListeners = element => {
+  const listeners = boundEventListeners.get(element);
+  if (!listeners) {
+    return;
+  }
+  listeners.forEach(_ref => {
+    let {
+      eventName,
+      listener
+    } = _ref;
+    element.removeEventListener(eventName, listener);
+  });
+  boundEventListeners.delete(element);
+};
+const dispatchCustomEvent = (element, eventName, detail) => {
+  element.dispatchEvent(new CustomEvent(eventName, {
+    bubbles: true,
+    detail
+  }));
+};
 
 const arrayHasValue = (value, otherValues) => {
   for (let i = 0, l = otherValues.length; i < l; i++) {
@@ -19,136 +53,190 @@ const createElementFromHTML = html => {
   element.innerHTML = html;
   return element.firstChild;
 };
+const isDOMCollection = target => {
+  return Array.isArray(target) || typeof NodeList !== 'undefined' && target instanceof NodeList || typeof HTMLCollection !== 'undefined' && target instanceof HTMLCollection || typeof RadioNodeList !== 'undefined' && target instanceof RadioNodeList;
+};
+const isDOMElement = target => {
+  return target != null && target.nodeType === 1;
+};
+const getDOMElements = target => {
+  if (target == null) {
+    return [];
+  }
+  if (isDOMElement(target)) {
+    return [target];
+  }
+  if (isDOMCollection(target)) {
+    return Array.from(target).filter(isDOMElement);
+  }
+  return [];
+};
+const isFormElement = element => {
+  return element.tagName === 'FORM';
+};
+const isInputElement = element => {
+  switch (element.tagName) {
+    case 'INPUT':
+      return element.type !== 'submit' && element.type !== 'button';
+    case 'SELECT':
+    case 'TEXTAREA':
+      return true;
+    default:
+      return false;
+  }
+};
+const isVisible = element => {
+  return Boolean(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
+};
 const isValuePresent = value => {
   return !/^\s*$/.test(value || '');
 };
 
+const isNamedInputElement = element => {
+  return isInputElement(element) && element.name != null && element.name !== '';
+};
+const getFormControls = form => {
+  return Array.from(form.elements).filter(isInputElement);
+};
+const getFormInputs = form => {
+  return getFormControls(form).filter(element => {
+    return isNamedInputElement(element) && !element.disabled && isVisible(element);
+  });
+};
+const findFormElementByName = (form, name) => {
+  return getFormControls(form).find(element => element.name === name);
+};
+const enableForm = form => {
+  ClientSideValidations.enablers.form(form);
+};
+const enableForms = () => {
+  document.querySelectorAll(ClientSideValidations.selectors.forms).forEach(enableForm);
+};
 const ClientSideValidations = {
   callbacks: {
     element: {
-      after: ($element, eventData) => {},
-      before: ($element, eventData) => {},
-      fail: ($element, message, addError, eventData) => addError(),
-      pass: ($element, removeError, eventData) => removeError()
+      after: (element, eventData) => {},
+      before: (element, eventData) => {},
+      fail: (element, message, addError, eventData) => addError(),
+      pass: (element, removeError, eventData) => removeError()
     },
     form: {
-      after: ($form, eventData) => {},
-      before: ($form, eventData) => {},
-      fail: ($form, eventData) => {},
-      pass: ($form, eventData) => {}
+      after: (form, eventData) => {},
+      before: (form, eventData) => {},
+      fail: (form, eventData) => {},
+      pass: (form, eventData) => {}
     }
   },
   eventsToBind: {
-    form: (form, $form) => ({
-      'submit.ClientSideValidations': eventData => {
-        if (!$form.isValid(form.ClientSideValidations.settings.validators)) {
+    form: form => ({
+      submit: eventData => {
+        if (!ClientSideValidations.isValid(form, form.ClientSideValidations.settings.validators)) {
           eventData.preventDefault();
           eventData.stopImmediatePropagation();
         }
       },
-      'ajax:beforeSend.ClientSideValidations': function (eventData) {
+      'ajax:beforeSend': function (eventData) {
         if (eventData.target === this) {
-          $form.isValid(form.ClientSideValidations.settings.validators);
+          ClientSideValidations.isValid(form, form.ClientSideValidations.settings.validators);
         }
       },
-      'form:validate:after.ClientSideValidations': eventData => {
-        ClientSideValidations.callbacks.form.after($form, eventData);
+      'form:validate:after': eventData => {
+        ClientSideValidations.callbacks.form.after(form, eventData);
       },
-      'form:validate:before.ClientSideValidations': eventData => {
-        ClientSideValidations.callbacks.form.before($form, eventData);
+      'form:validate:before': eventData => {
+        ClientSideValidations.callbacks.form.before(form, eventData);
       },
-      'form:validate:fail.ClientSideValidations': eventData => {
-        ClientSideValidations.callbacks.form.fail($form, eventData);
+      'form:validate:fail': eventData => {
+        ClientSideValidations.callbacks.form.fail(form, eventData);
       },
-      'form:validate:pass.ClientSideValidations': eventData => {
-        ClientSideValidations.callbacks.form.pass($form, eventData);
+      'form:validate:pass': eventData => {
+        ClientSideValidations.callbacks.form.pass(form, eventData);
       }
     }),
     input: form => ({
-      'focusout.ClientSideValidations': function () {
-        jQuery(this).isValid(form.ClientSideValidations.settings.validators);
+      focusout: function () {
+        ClientSideValidations.isValid(this, form.ClientSideValidations.settings.validators);
       },
-      'change.ClientSideValidations': function () {
+      change: function () {
         this.dataset.csvChanged = 'true';
       },
-      'element:validate:after.ClientSideValidations': function (eventData) {
-        ClientSideValidations.callbacks.element.after(jQuery(this), eventData);
+      'element:validate:after': function (eventData) {
+        ClientSideValidations.callbacks.element.after(this, eventData);
       },
-      'element:validate:before.ClientSideValidations': function (eventData) {
-        ClientSideValidations.callbacks.element.before(jQuery(this), eventData);
+      'element:validate:before': function (eventData) {
+        ClientSideValidations.callbacks.element.before(this, eventData);
       },
-      'element:validate:fail.ClientSideValidations': function (eventData, message) {
-        const $element = jQuery(this);
-        ClientSideValidations.callbacks.element.fail($element, message, function () {
-          form.ClientSideValidations.addError($element, message);
+      'element:validate:fail': function (eventData) {
+        const element = this;
+        const message = eventData.detail;
+        ClientSideValidations.callbacks.element.fail(element, message, function () {
+          form.ClientSideValidations.addError(element, message);
         }, eventData);
       },
-      'element:validate:pass.ClientSideValidations': function (eventData) {
-        const $element = jQuery(this);
-        ClientSideValidations.callbacks.element.pass($element, function () {
-          form.ClientSideValidations.removeError($element);
+      'element:validate:pass': function (eventData) {
+        const element = this;
+        ClientSideValidations.callbacks.element.pass(element, function () {
+          form.ClientSideValidations.removeError(element);
         }, eventData);
       }
     }),
-    inputConfirmation: ($element, form) => ({
-      'focusout.ClientSideValidations': () => {
-        $element[0].dataset.csvChanged = 'true';
-        $element.isValid(form.ClientSideValidations.settings.validators);
+    inputConfirmation: (elementToConfirm, form) => ({
+      focusout: () => {
+        elementToConfirm.dataset.csvChanged = 'true';
+        ClientSideValidations.isValid(elementToConfirm, form.ClientSideValidations.settings.validators);
       },
-      'keyup.ClientSideValidations': () => {
-        $element[0].dataset.csvChanged = 'true';
-        $element.isValid(form.ClientSideValidations.settings.validators);
+      keyup: () => {
+        elementToConfirm.dataset.csvChanged = 'true';
+        ClientSideValidations.isValid(elementToConfirm, form.ClientSideValidations.settings.validators);
       }
     })
   },
   enablers: {
     form: form => {
-      const $form = jQuery(form);
+      clearBoundEventListeners(form);
+      getFormControls(form).forEach(clearBoundEventListeners);
       form.ClientSideValidations = {
         settings: JSON.parse(form.dataset.clientSideValidations),
-        addError: ($element, message) => ClientSideValidations.formBuilders[form.ClientSideValidations.settings.html_settings.type].add($element, form.ClientSideValidations.settings.html_settings, message),
-        removeError: $element => ClientSideValidations.formBuilders[form.ClientSideValidations.settings.html_settings.type].remove($element, form.ClientSideValidations.settings.html_settings)
+        addError: (element, message) => ClientSideValidations.formBuilders[form.ClientSideValidations.settings.html_settings.type].add(element, form.ClientSideValidations.settings.html_settings, message),
+        removeError: element => ClientSideValidations.formBuilders[form.ClientSideValidations.settings.html_settings.type].remove(element, form.ClientSideValidations.settings.html_settings)
       };
-      const eventsToBind = ClientSideValidations.eventsToBind.form(form, $form);
-      for (const eventName in eventsToBind) {
-        const eventFunction = eventsToBind[eventName];
-        $form.on(eventName, eventFunction);
-      }
-      $form.find(ClientSideValidations.selectors.inputs).each(function () {
-        ClientSideValidations.enablers.input(this);
+      bindElementEvents(form, ClientSideValidations.eventsToBind.form(form));
+      getFormInputs(form).forEach(element => {
+        ClientSideValidations.enablers.input(element);
       });
     },
     input: function (input) {
-      const $input = jQuery(input);
       const form = input.form;
-      const $form = jQuery(form);
-      const eventsToBind = ClientSideValidations.eventsToBind.input(form);
-      for (const eventName in eventsToBind) {
-        const eventFunction = eventsToBind[eventName];
-        $input.filter(':not(:radio):not([id$=_confirmation])').each(function () {
-          this.dataset.csvValidate = 'true';
-        }).on(eventName, eventFunction);
+      if (!form) {
+        return;
       }
-      $input.filter(':checkbox').on('change.ClientSideValidations', function () {
-        jQuery(this).isValid(form.ClientSideValidations.settings.validators);
-      });
-      $input.filter('[id$=_confirmation]').each(function () {
-        const $element = jQuery(this);
-        const $elementToConfirm = $form.find("#".concat(this.id.match(/(.+)_confirmation/)[1], ":input"));
-        if ($elementToConfirm.length) {
-          const eventsToBind = ClientSideValidations.eventsToBind.inputConfirmation($elementToConfirm, form);
-          for (const eventName in eventsToBind) {
-            const eventFunction = eventsToBind[eventName];
-            jQuery("#".concat($element.attr('id'))).on(eventName, eventFunction);
+      clearBoundEventListeners(input);
+      const eventsToBind = ClientSideValidations.eventsToBind.input(form);
+      if (input.type !== 'radio' && !(input.id && input.id.endsWith('_confirmation'))) {
+        input.dataset.csvValidate = 'true';
+        bindElementEvents(input, eventsToBind);
+      }
+      if (input.type === 'checkbox') {
+        bindElementEvents(input, {
+          change: function () {
+            ClientSideValidations.isValid(this, form.ClientSideValidations.settings.validators);
           }
+        });
+      }
+      if (input.id && input.id.endsWith('_confirmation')) {
+        const elementToConfirm = document.getElementById(input.id.match(/(.+)_confirmation/)[1]);
+        if (elementToConfirm && elementToConfirm.form === form) {
+          bindElementEvents(input, ClientSideValidations.eventsToBind.inputConfirmation(elementToConfirm, form));
         }
-      });
+      }
     }
   },
   formBuilders: {
     'ActionView::Helpers::FormBuilder': {
-      add: ($element, settings, message) => {
-        const element = $element[0];
+      add: (element, settings, message) => {
+        if (!element) {
+          return;
+        }
         const form = element.form;
         const inputErrorTemplate = createElementFromHTML(settings.input_tag);
         let inputErrorElement = element.closest(".".concat(inputErrorTemplate.getAttribute('class').replace(/ /g, '.')));
@@ -178,8 +266,10 @@ const ClientSideValidations = {
           labelMessageElement.textContent = message;
         }
       },
-      remove: ($element, settings) => {
-        const element = $element[0];
+      remove: (element, settings) => {
+        if (!element) {
+          return;
+        }
         const form = element.form;
         const inputErrorClass = createElementFromHTML(settings.input_tag).getAttribute('class');
         const inputErrorElement = element.closest(".".concat(inputErrorClass.replace(/ /g, '.')));
@@ -209,8 +299,8 @@ const ClientSideValidations = {
     }
   },
   selectors: {
-    inputs: ':input:not(button):not([type="submit"])[name]:visible:enabled',
-    validate_inputs: ':input:enabled:visible[data-csv-validate]',
+    inputs: 'input:not([type="submit"]):not([type="button"])[name], select[name], textarea[name]',
+    validate_inputs: 'input[data-csv-validate]:not([type="submit"]):not([type="button"]), select[data-csv-validate], textarea[data-csv-validate]',
     forms: 'form[data-client-side-validations]'
   },
   validators: {
@@ -224,23 +314,31 @@ const ClientSideValidations = {
     remote: {}
   },
   disable: target => {
-    const $target = jQuery(target);
-    $target.off('.ClientSideValidations');
-    if ($target.is('form')) {
-      ClientSideValidations.disable($target.find(':input'));
-    } else {
-      delete $target[0].dataset.csvValid;
-      delete $target[0].dataset.csvChanged;
-      $target.filter(':input').each(function () {
-        delete this.dataset.csvValidate;
-      });
-    }
+    getDOMElements(target).forEach(element => {
+      clearBoundEventListeners(element);
+      if (isFormElement(element)) {
+        getFormControls(element).forEach(input => {
+          clearBoundEventListeners(input);
+          delete input.dataset.csvValid;
+          delete input.dataset.csvChanged;
+          delete input.dataset.csvValidate;
+        });
+        return;
+      }
+      delete element.dataset.csvValid;
+      delete element.dataset.csvChanged;
+      if (isInputElement(element)) {
+        delete element.dataset.csvValidate;
+      }
+    });
   },
   reset: form => {
-    const $form = jQuery(form);
     ClientSideValidations.disable(form);
     for (const key in form.ClientSideValidations.settings.validators) {
-      form.ClientSideValidations.removeError($form.find("[name=\"".concat(key, "\"]")));
+      const element = findFormElementByName(form, key);
+      if (element) {
+        form.ClientSideValidations.removeError(element);
+      }
     }
     ClientSideValidations.enablers.form(form);
   },
@@ -254,21 +352,23 @@ const ClientSideValidations = {
   start: () => {
     const initializeOnEvent = ClientSideValidations.initializeOnEvent();
     if (initializeOnEvent != null) {
-      jQuery(document).on(initializeOnEvent, () => jQuery(ClientSideValidations.selectors.forms).validate());
+      document.addEventListener(initializeOnEvent, enableForms);
+    } else if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', enableForms, {
+        once: true
+      });
     } else {
-      jQuery(() => jQuery(ClientSideValidations.selectors.forms).validate());
+      enableForms();
     }
   }
 };
 
-const absenceLocalValidator = ($element, options) => {
-  const element = $element[0];
+const absenceLocalValidator = (element, options) => {
   if (isValuePresent(element.value)) {
     return options.message;
   }
 };
-const presenceLocalValidator = ($element, options) => {
-  const element = $element[0];
+const presenceLocalValidator = (element, options) => {
   if (!isValuePresent(element.value)) {
     return options.message;
   }
@@ -284,8 +384,7 @@ const isTextAccepted = (value, acceptOption) => {
   }
   return value === acceptOption;
 };
-const acceptanceLocalValidator = ($element, options) => {
-  const element = $element[0];
+const acceptanceLocalValidator = (element, options) => {
   let valid = true;
   if (element.type === 'checkbox') {
     valid = element.checked;
@@ -304,8 +403,7 @@ const isMatching = (value, regExpOptions) => {
 const hasValidFormat = (value, withOptions, withoutOptions) => {
   return withOptions && isMatching(value, withOptions) || withoutOptions && !isMatching(value, withoutOptions);
 };
-const formatLocalValidator = ($element, options) => {
-  const element = $element[0];
+const formatLocalValidator = (element, options) => {
   const value = element.value;
   if (options.allow_blank && !isValuePresent(value)) {
     return;
@@ -390,8 +488,7 @@ const runValidations$1 = (formattedValue, form, options) => {
   }
   return runFunctionValidations(formattedValue, form, options);
 };
-const numericalityLocalValidator = ($element, options) => {
-  const element = $element[0];
+const numericalityLocalValidator = (element, options) => {
   const value = element.value;
   if (options.allow_blank && !isValuePresent(value)) {
     return;
@@ -421,8 +518,7 @@ const runValidations = (valueLength, options) => {
     }
   }
 };
-const lengthLocalValidator = ($element, options) => {
-  const element = $element[0];
+const lengthLocalValidator = (element, options) => {
   const value = element.value;
   if (options.allow_blank && !isValuePresent(value)) {
     return;
@@ -446,23 +542,20 @@ const isIncluded = (value, options, allowBlank) => {
   }
   return options.in && isInList(value, options.in) || options.range && isInRange(value, options.range);
 };
-const exclusionLocalValidator = ($element, options) => {
-  const element = $element[0];
+const exclusionLocalValidator = (element, options) => {
   const value = element.value;
   if (isIncluded(value, options, false) || !options.allow_blank && !isValuePresent(value)) {
     return options.message;
   }
 };
-const inclusionLocalValidator = ($element, options) => {
-  const element = $element[0];
+const inclusionLocalValidator = (element, options) => {
   const value = element.value;
   if (!isIncluded(value, options, true)) {
     return options.message;
   }
 };
 
-const confirmationLocalValidator = ($element, options) => {
-  const element = $element[0];
+const confirmationLocalValidator = (element, options) => {
   let value = element.value;
   let confirmationValue = document.getElementById("".concat(element.id, "_confirmation")).value;
   if (!options.case_sensitive) {
@@ -480,17 +573,16 @@ const isLocallyUnique = (element, value, otherValue, caseSensitive) => {
     otherValue = otherValue.toLowerCase();
   }
   if (otherValue === value) {
-    element.dataset.notLocallyUnique = true;
+    element.dataset.csvNotLocallyUnique = 'true';
     return false;
   }
-  if (element.dataset.notLocallyUnique) {
-    delete element.dataset.notLocallyUnique;
-    element.dataset.changed = true;
+  if (element.dataset.csvNotLocallyUnique) {
+    delete element.dataset.csvNotLocallyUnique;
+    element.dataset.csvChanged = 'true';
   }
   return true;
 };
-const uniquenessLocalValidator = ($element, options) => {
-  const element = $element[0];
+const uniquenessLocalValidator = (element, options) => {
   const elementName = element.name;
   const matches = elementName.match(/^(.+_attributes\])\[\d+\](.+)$/);
   if (!matches) {
@@ -525,42 +617,38 @@ ClientSideValidations.validators.local = {
   confirmation: confirmationLocalValidator,
   uniqueness: uniquenessLocalValidator
 };
-jQuery.fn.disableClientSideValidations = function () {
-  ClientSideValidations.disable(this);
-  return this;
-};
-jQuery.fn.enableClientSideValidations = function () {
-  const selectors = {
-    forms: 'form',
-    inputs: 'input'
-  };
-  for (const selector in selectors) {
-    const enablers = selectors[selector];
-    this.filter(ClientSideValidations.selectors[selector]).each(function () {
-      ClientSideValidations.enablers[enablers](this);
-    });
-  }
-  return this;
-};
-jQuery.fn.resetClientSideValidations = function () {
-  this.filter(ClientSideValidations.selectors.forms).each(function () {
-    ClientSideValidations.reset(this);
+ClientSideValidations.enable = target => {
+  getDOMElements(target).forEach(element => {
+    if (isFormElement(element)) {
+      ClientSideValidations.enablers.form(element);
+    } else if (isInputElement(element)) {
+      ClientSideValidations.enablers.input(element);
+    }
   });
-  return this;
+  return target;
 };
-jQuery.fn.validate = function () {
-  this.filter(ClientSideValidations.selectors.forms).each(function () {
-    jQuery(this).enableClientSideValidations();
+ClientSideValidations.validate = target => {
+  getDOMElements(target).forEach(element => {
+    if (isFormElement(element)) {
+      ClientSideValidations.enable(element);
+    }
   });
-  return this;
+  return target;
 };
-jQuery.fn.isValid = function (validators) {
-  const obj = jQuery(this[0]);
-  if (obj.is('form')) {
-    return validateForm(obj, validators);
-  } else {
-    return validateElement(obj, validatorsFor(this[0].name, validators));
+ClientSideValidations.isValid = (target, validators) => {
+  const element = getDOMElements(target)[0];
+  if (!element) {
+    return true;
   }
+  if (!validators) {
+    var _form$ClientSideValid;
+    const form = isFormElement(element) ? element : element.form;
+    validators = form === null || form === void 0 || (_form$ClientSideValid = form.ClientSideValidations) === null || _form$ClientSideValid === void 0 || (_form$ClientSideValid = _form$ClientSideValid.settings) === null || _form$ClientSideValid === void 0 ? void 0 : _form$ClientSideValid.validators;
+  }
+  if (isFormElement(element)) {
+    return validateForm(element, validators || {});
+  }
+  return validateElement(element, validatorsFor(element.name, validators || {}));
 };
 const cleanNestedElementName = (elementName, nestedMatches, validators) => {
   for (const validatorName in validators) {
@@ -579,97 +667,103 @@ const cleanElementName = (elementName, validators) => {
   return elementName;
 };
 const validatorsFor = (elementName, validators) => {
+  if (!elementName || !validators) {
+    return {};
+  }
   if (Object.prototype.hasOwnProperty.call(validators, elementName)) {
     return validators[elementName];
   }
   return validators[cleanElementName(elementName, validators)] || {};
 };
-const validateForm = ($form, validators) => {
+const getValidationInputs = form => {
+  return Array.from(form.elements).filter(element => {
+    if (element.dataset.csvValidate == null || element.disabled) {
+      return false;
+    }
+    return isVisible(element);
+  });
+};
+const validateForm = (form, validators) => {
   let valid = true;
-  $form.trigger('form:validate:before.ClientSideValidations');
-  $form.find(ClientSideValidations.selectors.validate_inputs).each(function () {
-    if (!jQuery(this).isValid(validators)) {
+  dispatchCustomEvent(form, 'form:validate:before');
+  getValidationInputs(form).forEach(element => {
+    if (!validateElement(element, validatorsFor(element.name, validators))) {
       valid = false;
     }
-    return true;
   });
   if (valid) {
-    $form.trigger('form:validate:pass.ClientSideValidations');
+    dispatchCustomEvent(form, 'form:validate:pass');
   } else {
-    $form.trigger('form:validate:fail.ClientSideValidations');
+    dispatchCustomEvent(form, 'form:validate:fail');
   }
-  $form.trigger('form:validate:after.ClientSideValidations');
+  dispatchCustomEvent(form, 'form:validate:after');
   return valid;
 };
-const passElement = $element => {
-  const element = $element[0];
-  $element.trigger('element:validate:pass.ClientSideValidations');
+const passElement = element => {
+  dispatchCustomEvent(element, 'element:validate:pass');
   delete element.dataset.csvValid;
 };
-const failElement = ($element, message) => {
-  const element = $element[0];
-  $element.trigger('element:validate:fail.ClientSideValidations', message);
+const failElement = (element, message) => {
+  dispatchCustomEvent(element, 'element:validate:fail', message);
   element.dataset.csvValid = 'false';
 };
-const afterValidate = $element => {
-  const element = $element[0];
-  $element.trigger('element:validate:after.ClientSideValidations');
+const afterValidate = element => {
+  dispatchCustomEvent(element, 'element:validate:after');
   return element.dataset.csvValid !== 'false';
 };
-const executeValidator = (validatorFunctions, validatorFunction, validatorOptions, $element) => {
+const executeValidator = (validatorFunctions, validatorFunction, validatorOptions, element) => {
   for (const validatorOption in validatorOptions) {
     if (!validatorOptions[validatorOption]) {
       continue;
     }
-    const message = validatorFunction.call(validatorFunctions, $element, validatorOptions[validatorOption]);
+    const message = validatorFunction.call(validatorFunctions, element, validatorOptions[validatorOption]);
     if (message) {
-      failElement($element, message);
+      failElement(element, message);
       return false;
     }
   }
   return true;
 };
-const executeValidators = (validatorFunctions, $element, validators) => {
+const executeValidators = (validatorFunctions, element, validators) => {
   for (const validator in validators) {
     if (!validatorFunctions[validator]) {
       continue;
     }
-    if (!executeValidator(validatorFunctions, validatorFunctions[validator], validators[validator], $element)) {
+    if (!executeValidator(validatorFunctions, validatorFunctions[validator], validators[validator], element)) {
       return false;
     }
   }
   return true;
 };
-const isMarkedForDestroy = $element => {
-  const element = $element[0];
+const isMarkedForDestroy = element => {
   const elementName = element.name;
-  if (/\[([^\]]*?)\]$/.test(elementName)) {
+  const form = element.form;
+  if (form && /\[([^\]]*?)\]$/.test(elementName)) {
     const destroyInputName = elementName.replace(/\[([^\]]*?)\]$/, '[_destroy]');
-    const destroyInputElement = document.querySelector("input[name=\"".concat(destroyInputName, "\"]"));
+    const destroyInputElement = form.querySelector("input[name=\"".concat(destroyInputName, "\"]"));
     if (destroyInputElement && destroyInputElement.value === '1') {
       return true;
     }
   }
   return false;
 };
-const executeAllValidators = ($element, validators) => {
-  const element = $element[0];
+const executeAllValidators = (element, validators) => {
   if (element.dataset.csvChanged === 'false' || element.disabled) {
     return;
   }
   element.dataset.csvChanged = 'false';
-  if (executeValidators(ClientSideValidations.validators.all(), $element, validators)) {
-    passElement($element);
+  if (executeValidators(ClientSideValidations.validators.all(), element, validators)) {
+    passElement(element);
   }
 };
-const validateElement = ($element, validators) => {
-  $element.trigger('element:validate:before.ClientSideValidations');
-  if (isMarkedForDestroy($element)) {
-    passElement($element);
+const validateElement = (element, validators) => {
+  dispatchCustomEvent(element, 'element:validate:before');
+  if (isMarkedForDestroy(element)) {
+    passElement(element);
   } else {
-    executeAllValidators($element, validators);
+    executeAllValidators(element, validators);
   }
-  return afterValidate($element);
+  return afterValidate(element);
 };
 if (!window.ClientSideValidations) {
   window.ClientSideValidations = ClientSideValidations;

--- a/dist/client-side-validations.js
+++ b/dist/client-side-validations.js
@@ -1,14 +1,50 @@
 /*!
- * Client Side Validations JS - v23.1.0 (https://github.com/DavyJonesLocker/client_side_validations)
+ * Client Side Validations JS - v24.0.0 (https://github.com/DavyJonesLocker/client_side_validations)
  * Copyright (c) 2026 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */
 
 (function (global, factory) {
-  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(require('jquery')) :
-  typeof define === 'function' && define.amd ? define(['jquery'], factory) :
-  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, global.ClientSideValidations = factory(global.jQuery));
-})(this, (function (jQuery) { 'use strict';
+  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+  typeof define === 'function' && define.amd ? define(factory) :
+  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, global.ClientSideValidations = factory());
+})(this, (function () { 'use strict';
+
+  const boundEventListeners = new WeakMap();
+  const addBoundEventListener = (element, eventName, listener) => {
+    element.addEventListener(eventName, listener);
+    const listeners = boundEventListeners.get(element) || [];
+    listeners.push({
+      eventName,
+      listener
+    });
+    boundEventListeners.set(element, listeners);
+  };
+  const bindElementEvents = (element, eventsToBind) => {
+    for (const eventName in eventsToBind) {
+      addBoundEventListener(element, eventName, eventsToBind[eventName]);
+    }
+  };
+  const clearBoundEventListeners = element => {
+    const listeners = boundEventListeners.get(element);
+    if (!listeners) {
+      return;
+    }
+    listeners.forEach(_ref => {
+      let {
+        eventName,
+        listener
+      } = _ref;
+      element.removeEventListener(eventName, listener);
+    });
+    boundEventListeners.delete(element);
+  };
+  const dispatchCustomEvent = (element, eventName, detail) => {
+    element.dispatchEvent(new CustomEvent(eventName, {
+      bubbles: true,
+      detail
+    }));
+  };
 
   const arrayHasValue = (value, otherValues) => {
     for (let i = 0, l = otherValues.length; i < l; i++) {
@@ -23,136 +59,190 @@
     element.innerHTML = html;
     return element.firstChild;
   };
+  const isDOMCollection = target => {
+    return Array.isArray(target) || typeof NodeList !== 'undefined' && target instanceof NodeList || typeof HTMLCollection !== 'undefined' && target instanceof HTMLCollection || typeof RadioNodeList !== 'undefined' && target instanceof RadioNodeList;
+  };
+  const isDOMElement = target => {
+    return target != null && target.nodeType === 1;
+  };
+  const getDOMElements = target => {
+    if (target == null) {
+      return [];
+    }
+    if (isDOMElement(target)) {
+      return [target];
+    }
+    if (isDOMCollection(target)) {
+      return Array.from(target).filter(isDOMElement);
+    }
+    return [];
+  };
+  const isFormElement = element => {
+    return element.tagName === 'FORM';
+  };
+  const isInputElement = element => {
+    switch (element.tagName) {
+      case 'INPUT':
+        return element.type !== 'submit' && element.type !== 'button';
+      case 'SELECT':
+      case 'TEXTAREA':
+        return true;
+      default:
+        return false;
+    }
+  };
+  const isVisible = element => {
+    return Boolean(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
+  };
   const isValuePresent = value => {
     return !/^\s*$/.test(value || '');
   };
 
+  const isNamedInputElement = element => {
+    return isInputElement(element) && element.name != null && element.name !== '';
+  };
+  const getFormControls = form => {
+    return Array.from(form.elements).filter(isInputElement);
+  };
+  const getFormInputs = form => {
+    return getFormControls(form).filter(element => {
+      return isNamedInputElement(element) && !element.disabled && isVisible(element);
+    });
+  };
+  const findFormElementByName = (form, name) => {
+    return getFormControls(form).find(element => element.name === name);
+  };
+  const enableForm = form => {
+    ClientSideValidations.enablers.form(form);
+  };
+  const enableForms = () => {
+    document.querySelectorAll(ClientSideValidations.selectors.forms).forEach(enableForm);
+  };
   const ClientSideValidations = {
     callbacks: {
       element: {
-        after: ($element, eventData) => {},
-        before: ($element, eventData) => {},
-        fail: ($element, message, addError, eventData) => addError(),
-        pass: ($element, removeError, eventData) => removeError()
+        after: (element, eventData) => {},
+        before: (element, eventData) => {},
+        fail: (element, message, addError, eventData) => addError(),
+        pass: (element, removeError, eventData) => removeError()
       },
       form: {
-        after: ($form, eventData) => {},
-        before: ($form, eventData) => {},
-        fail: ($form, eventData) => {},
-        pass: ($form, eventData) => {}
+        after: (form, eventData) => {},
+        before: (form, eventData) => {},
+        fail: (form, eventData) => {},
+        pass: (form, eventData) => {}
       }
     },
     eventsToBind: {
-      form: (form, $form) => ({
-        'submit.ClientSideValidations': eventData => {
-          if (!$form.isValid(form.ClientSideValidations.settings.validators)) {
+      form: form => ({
+        submit: eventData => {
+          if (!ClientSideValidations.isValid(form, form.ClientSideValidations.settings.validators)) {
             eventData.preventDefault();
             eventData.stopImmediatePropagation();
           }
         },
-        'ajax:beforeSend.ClientSideValidations': function (eventData) {
+        'ajax:beforeSend': function (eventData) {
           if (eventData.target === this) {
-            $form.isValid(form.ClientSideValidations.settings.validators);
+            ClientSideValidations.isValid(form, form.ClientSideValidations.settings.validators);
           }
         },
-        'form:validate:after.ClientSideValidations': eventData => {
-          ClientSideValidations.callbacks.form.after($form, eventData);
+        'form:validate:after': eventData => {
+          ClientSideValidations.callbacks.form.after(form, eventData);
         },
-        'form:validate:before.ClientSideValidations': eventData => {
-          ClientSideValidations.callbacks.form.before($form, eventData);
+        'form:validate:before': eventData => {
+          ClientSideValidations.callbacks.form.before(form, eventData);
         },
-        'form:validate:fail.ClientSideValidations': eventData => {
-          ClientSideValidations.callbacks.form.fail($form, eventData);
+        'form:validate:fail': eventData => {
+          ClientSideValidations.callbacks.form.fail(form, eventData);
         },
-        'form:validate:pass.ClientSideValidations': eventData => {
-          ClientSideValidations.callbacks.form.pass($form, eventData);
+        'form:validate:pass': eventData => {
+          ClientSideValidations.callbacks.form.pass(form, eventData);
         }
       }),
       input: form => ({
-        'focusout.ClientSideValidations': function () {
-          jQuery(this).isValid(form.ClientSideValidations.settings.validators);
+        focusout: function () {
+          ClientSideValidations.isValid(this, form.ClientSideValidations.settings.validators);
         },
-        'change.ClientSideValidations': function () {
+        change: function () {
           this.dataset.csvChanged = 'true';
         },
-        'element:validate:after.ClientSideValidations': function (eventData) {
-          ClientSideValidations.callbacks.element.after(jQuery(this), eventData);
+        'element:validate:after': function (eventData) {
+          ClientSideValidations.callbacks.element.after(this, eventData);
         },
-        'element:validate:before.ClientSideValidations': function (eventData) {
-          ClientSideValidations.callbacks.element.before(jQuery(this), eventData);
+        'element:validate:before': function (eventData) {
+          ClientSideValidations.callbacks.element.before(this, eventData);
         },
-        'element:validate:fail.ClientSideValidations': function (eventData, message) {
-          const $element = jQuery(this);
-          ClientSideValidations.callbacks.element.fail($element, message, function () {
-            form.ClientSideValidations.addError($element, message);
+        'element:validate:fail': function (eventData) {
+          const element = this;
+          const message = eventData.detail;
+          ClientSideValidations.callbacks.element.fail(element, message, function () {
+            form.ClientSideValidations.addError(element, message);
           }, eventData);
         },
-        'element:validate:pass.ClientSideValidations': function (eventData) {
-          const $element = jQuery(this);
-          ClientSideValidations.callbacks.element.pass($element, function () {
-            form.ClientSideValidations.removeError($element);
+        'element:validate:pass': function (eventData) {
+          const element = this;
+          ClientSideValidations.callbacks.element.pass(element, function () {
+            form.ClientSideValidations.removeError(element);
           }, eventData);
         }
       }),
-      inputConfirmation: ($element, form) => ({
-        'focusout.ClientSideValidations': () => {
-          $element[0].dataset.csvChanged = 'true';
-          $element.isValid(form.ClientSideValidations.settings.validators);
+      inputConfirmation: (elementToConfirm, form) => ({
+        focusout: () => {
+          elementToConfirm.dataset.csvChanged = 'true';
+          ClientSideValidations.isValid(elementToConfirm, form.ClientSideValidations.settings.validators);
         },
-        'keyup.ClientSideValidations': () => {
-          $element[0].dataset.csvChanged = 'true';
-          $element.isValid(form.ClientSideValidations.settings.validators);
+        keyup: () => {
+          elementToConfirm.dataset.csvChanged = 'true';
+          ClientSideValidations.isValid(elementToConfirm, form.ClientSideValidations.settings.validators);
         }
       })
     },
     enablers: {
       form: form => {
-        const $form = jQuery(form);
+        clearBoundEventListeners(form);
+        getFormControls(form).forEach(clearBoundEventListeners);
         form.ClientSideValidations = {
           settings: JSON.parse(form.dataset.clientSideValidations),
-          addError: ($element, message) => ClientSideValidations.formBuilders[form.ClientSideValidations.settings.html_settings.type].add($element, form.ClientSideValidations.settings.html_settings, message),
-          removeError: $element => ClientSideValidations.formBuilders[form.ClientSideValidations.settings.html_settings.type].remove($element, form.ClientSideValidations.settings.html_settings)
+          addError: (element, message) => ClientSideValidations.formBuilders[form.ClientSideValidations.settings.html_settings.type].add(element, form.ClientSideValidations.settings.html_settings, message),
+          removeError: element => ClientSideValidations.formBuilders[form.ClientSideValidations.settings.html_settings.type].remove(element, form.ClientSideValidations.settings.html_settings)
         };
-        const eventsToBind = ClientSideValidations.eventsToBind.form(form, $form);
-        for (const eventName in eventsToBind) {
-          const eventFunction = eventsToBind[eventName];
-          $form.on(eventName, eventFunction);
-        }
-        $form.find(ClientSideValidations.selectors.inputs).each(function () {
-          ClientSideValidations.enablers.input(this);
+        bindElementEvents(form, ClientSideValidations.eventsToBind.form(form));
+        getFormInputs(form).forEach(element => {
+          ClientSideValidations.enablers.input(element);
         });
       },
       input: function (input) {
-        const $input = jQuery(input);
         const form = input.form;
-        const $form = jQuery(form);
-        const eventsToBind = ClientSideValidations.eventsToBind.input(form);
-        for (const eventName in eventsToBind) {
-          const eventFunction = eventsToBind[eventName];
-          $input.filter(':not(:radio):not([id$=_confirmation])').each(function () {
-            this.dataset.csvValidate = 'true';
-          }).on(eventName, eventFunction);
+        if (!form) {
+          return;
         }
-        $input.filter(':checkbox').on('change.ClientSideValidations', function () {
-          jQuery(this).isValid(form.ClientSideValidations.settings.validators);
-        });
-        $input.filter('[id$=_confirmation]').each(function () {
-          const $element = jQuery(this);
-          const $elementToConfirm = $form.find("#".concat(this.id.match(/(.+)_confirmation/)[1], ":input"));
-          if ($elementToConfirm.length) {
-            const eventsToBind = ClientSideValidations.eventsToBind.inputConfirmation($elementToConfirm, form);
-            for (const eventName in eventsToBind) {
-              const eventFunction = eventsToBind[eventName];
-              jQuery("#".concat($element.attr('id'))).on(eventName, eventFunction);
+        clearBoundEventListeners(input);
+        const eventsToBind = ClientSideValidations.eventsToBind.input(form);
+        if (input.type !== 'radio' && !(input.id && input.id.endsWith('_confirmation'))) {
+          input.dataset.csvValidate = 'true';
+          bindElementEvents(input, eventsToBind);
+        }
+        if (input.type === 'checkbox') {
+          bindElementEvents(input, {
+            change: function () {
+              ClientSideValidations.isValid(this, form.ClientSideValidations.settings.validators);
             }
+          });
+        }
+        if (input.id && input.id.endsWith('_confirmation')) {
+          const elementToConfirm = document.getElementById(input.id.match(/(.+)_confirmation/)[1]);
+          if (elementToConfirm && elementToConfirm.form === form) {
+            bindElementEvents(input, ClientSideValidations.eventsToBind.inputConfirmation(elementToConfirm, form));
           }
-        });
+        }
       }
     },
     formBuilders: {
       'ActionView::Helpers::FormBuilder': {
-        add: ($element, settings, message) => {
-          const element = $element[0];
+        add: (element, settings, message) => {
+          if (!element) {
+            return;
+          }
           const form = element.form;
           const inputErrorTemplate = createElementFromHTML(settings.input_tag);
           let inputErrorElement = element.closest(".".concat(inputErrorTemplate.getAttribute('class').replace(/ /g, '.')));
@@ -182,8 +272,10 @@
             labelMessageElement.textContent = message;
           }
         },
-        remove: ($element, settings) => {
-          const element = $element[0];
+        remove: (element, settings) => {
+          if (!element) {
+            return;
+          }
           const form = element.form;
           const inputErrorClass = createElementFromHTML(settings.input_tag).getAttribute('class');
           const inputErrorElement = element.closest(".".concat(inputErrorClass.replace(/ /g, '.')));
@@ -213,8 +305,8 @@
       }
     },
     selectors: {
-      inputs: ':input:not(button):not([type="submit"])[name]:visible:enabled',
-      validate_inputs: ':input:enabled:visible[data-csv-validate]',
+      inputs: 'input:not([type="submit"]):not([type="button"])[name], select[name], textarea[name]',
+      validate_inputs: 'input[data-csv-validate]:not([type="submit"]):not([type="button"]), select[data-csv-validate], textarea[data-csv-validate]',
       forms: 'form[data-client-side-validations]'
     },
     validators: {
@@ -228,23 +320,31 @@
       remote: {}
     },
     disable: target => {
-      const $target = jQuery(target);
-      $target.off('.ClientSideValidations');
-      if ($target.is('form')) {
-        ClientSideValidations.disable($target.find(':input'));
-      } else {
-        delete $target[0].dataset.csvValid;
-        delete $target[0].dataset.csvChanged;
-        $target.filter(':input').each(function () {
-          delete this.dataset.csvValidate;
-        });
-      }
+      getDOMElements(target).forEach(element => {
+        clearBoundEventListeners(element);
+        if (isFormElement(element)) {
+          getFormControls(element).forEach(input => {
+            clearBoundEventListeners(input);
+            delete input.dataset.csvValid;
+            delete input.dataset.csvChanged;
+            delete input.dataset.csvValidate;
+          });
+          return;
+        }
+        delete element.dataset.csvValid;
+        delete element.dataset.csvChanged;
+        if (isInputElement(element)) {
+          delete element.dataset.csvValidate;
+        }
+      });
     },
     reset: form => {
-      const $form = jQuery(form);
       ClientSideValidations.disable(form);
       for (const key in form.ClientSideValidations.settings.validators) {
-        form.ClientSideValidations.removeError($form.find("[name=\"".concat(key, "\"]")));
+        const element = findFormElementByName(form, key);
+        if (element) {
+          form.ClientSideValidations.removeError(element);
+        }
       }
       ClientSideValidations.enablers.form(form);
     },
@@ -258,21 +358,23 @@
     start: () => {
       const initializeOnEvent = ClientSideValidations.initializeOnEvent();
       if (initializeOnEvent != null) {
-        jQuery(document).on(initializeOnEvent, () => jQuery(ClientSideValidations.selectors.forms).validate());
+        document.addEventListener(initializeOnEvent, enableForms);
+      } else if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', enableForms, {
+          once: true
+        });
       } else {
-        jQuery(() => jQuery(ClientSideValidations.selectors.forms).validate());
+        enableForms();
       }
     }
   };
 
-  const absenceLocalValidator = ($element, options) => {
-    const element = $element[0];
+  const absenceLocalValidator = (element, options) => {
     if (isValuePresent(element.value)) {
       return options.message;
     }
   };
-  const presenceLocalValidator = ($element, options) => {
-    const element = $element[0];
+  const presenceLocalValidator = (element, options) => {
     if (!isValuePresent(element.value)) {
       return options.message;
     }
@@ -288,8 +390,7 @@
     }
     return value === acceptOption;
   };
-  const acceptanceLocalValidator = ($element, options) => {
-    const element = $element[0];
+  const acceptanceLocalValidator = (element, options) => {
     let valid = true;
     if (element.type === 'checkbox') {
       valid = element.checked;
@@ -308,8 +409,7 @@
   const hasValidFormat = (value, withOptions, withoutOptions) => {
     return withOptions && isMatching(value, withOptions) || withoutOptions && !isMatching(value, withoutOptions);
   };
-  const formatLocalValidator = ($element, options) => {
-    const element = $element[0];
+  const formatLocalValidator = (element, options) => {
     const value = element.value;
     if (options.allow_blank && !isValuePresent(value)) {
       return;
@@ -394,8 +494,7 @@
     }
     return runFunctionValidations(formattedValue, form, options);
   };
-  const numericalityLocalValidator = ($element, options) => {
-    const element = $element[0];
+  const numericalityLocalValidator = (element, options) => {
     const value = element.value;
     if (options.allow_blank && !isValuePresent(value)) {
       return;
@@ -425,8 +524,7 @@
       }
     }
   };
-  const lengthLocalValidator = ($element, options) => {
-    const element = $element[0];
+  const lengthLocalValidator = (element, options) => {
     const value = element.value;
     if (options.allow_blank && !isValuePresent(value)) {
       return;
@@ -450,23 +548,20 @@
     }
     return options.in && isInList(value, options.in) || options.range && isInRange(value, options.range);
   };
-  const exclusionLocalValidator = ($element, options) => {
-    const element = $element[0];
+  const exclusionLocalValidator = (element, options) => {
     const value = element.value;
     if (isIncluded(value, options, false) || !options.allow_blank && !isValuePresent(value)) {
       return options.message;
     }
   };
-  const inclusionLocalValidator = ($element, options) => {
-    const element = $element[0];
+  const inclusionLocalValidator = (element, options) => {
     const value = element.value;
     if (!isIncluded(value, options, true)) {
       return options.message;
     }
   };
 
-  const confirmationLocalValidator = ($element, options) => {
-    const element = $element[0];
+  const confirmationLocalValidator = (element, options) => {
     let value = element.value;
     let confirmationValue = document.getElementById("".concat(element.id, "_confirmation")).value;
     if (!options.case_sensitive) {
@@ -484,17 +579,16 @@
       otherValue = otherValue.toLowerCase();
     }
     if (otherValue === value) {
-      element.dataset.notLocallyUnique = true;
+      element.dataset.csvNotLocallyUnique = 'true';
       return false;
     }
-    if (element.dataset.notLocallyUnique) {
-      delete element.dataset.notLocallyUnique;
-      element.dataset.changed = true;
+    if (element.dataset.csvNotLocallyUnique) {
+      delete element.dataset.csvNotLocallyUnique;
+      element.dataset.csvChanged = 'true';
     }
     return true;
   };
-  const uniquenessLocalValidator = ($element, options) => {
-    const element = $element[0];
+  const uniquenessLocalValidator = (element, options) => {
     const elementName = element.name;
     const matches = elementName.match(/^(.+_attributes\])\[\d+\](.+)$/);
     if (!matches) {
@@ -529,42 +623,38 @@
     confirmation: confirmationLocalValidator,
     uniqueness: uniquenessLocalValidator
   };
-  jQuery.fn.disableClientSideValidations = function () {
-    ClientSideValidations.disable(this);
-    return this;
-  };
-  jQuery.fn.enableClientSideValidations = function () {
-    const selectors = {
-      forms: 'form',
-      inputs: 'input'
-    };
-    for (const selector in selectors) {
-      const enablers = selectors[selector];
-      this.filter(ClientSideValidations.selectors[selector]).each(function () {
-        ClientSideValidations.enablers[enablers](this);
-      });
-    }
-    return this;
-  };
-  jQuery.fn.resetClientSideValidations = function () {
-    this.filter(ClientSideValidations.selectors.forms).each(function () {
-      ClientSideValidations.reset(this);
+  ClientSideValidations.enable = target => {
+    getDOMElements(target).forEach(element => {
+      if (isFormElement(element)) {
+        ClientSideValidations.enablers.form(element);
+      } else if (isInputElement(element)) {
+        ClientSideValidations.enablers.input(element);
+      }
     });
-    return this;
+    return target;
   };
-  jQuery.fn.validate = function () {
-    this.filter(ClientSideValidations.selectors.forms).each(function () {
-      jQuery(this).enableClientSideValidations();
+  ClientSideValidations.validate = target => {
+    getDOMElements(target).forEach(element => {
+      if (isFormElement(element)) {
+        ClientSideValidations.enable(element);
+      }
     });
-    return this;
+    return target;
   };
-  jQuery.fn.isValid = function (validators) {
-    const obj = jQuery(this[0]);
-    if (obj.is('form')) {
-      return validateForm(obj, validators);
-    } else {
-      return validateElement(obj, validatorsFor(this[0].name, validators));
+  ClientSideValidations.isValid = (target, validators) => {
+    const element = getDOMElements(target)[0];
+    if (!element) {
+      return true;
     }
+    if (!validators) {
+      var _form$ClientSideValid;
+      const form = isFormElement(element) ? element : element.form;
+      validators = form === null || form === void 0 || (_form$ClientSideValid = form.ClientSideValidations) === null || _form$ClientSideValid === void 0 || (_form$ClientSideValid = _form$ClientSideValid.settings) === null || _form$ClientSideValid === void 0 ? void 0 : _form$ClientSideValid.validators;
+    }
+    if (isFormElement(element)) {
+      return validateForm(element, validators || {});
+    }
+    return validateElement(element, validatorsFor(element.name, validators || {}));
   };
   const cleanNestedElementName = (elementName, nestedMatches, validators) => {
     for (const validatorName in validators) {
@@ -583,97 +673,103 @@
     return elementName;
   };
   const validatorsFor = (elementName, validators) => {
+    if (!elementName || !validators) {
+      return {};
+    }
     if (Object.prototype.hasOwnProperty.call(validators, elementName)) {
       return validators[elementName];
     }
     return validators[cleanElementName(elementName, validators)] || {};
   };
-  const validateForm = ($form, validators) => {
+  const getValidationInputs = form => {
+    return Array.from(form.elements).filter(element => {
+      if (element.dataset.csvValidate == null || element.disabled) {
+        return false;
+      }
+      return isVisible(element);
+    });
+  };
+  const validateForm = (form, validators) => {
     let valid = true;
-    $form.trigger('form:validate:before.ClientSideValidations');
-    $form.find(ClientSideValidations.selectors.validate_inputs).each(function () {
-      if (!jQuery(this).isValid(validators)) {
+    dispatchCustomEvent(form, 'form:validate:before');
+    getValidationInputs(form).forEach(element => {
+      if (!validateElement(element, validatorsFor(element.name, validators))) {
         valid = false;
       }
-      return true;
     });
     if (valid) {
-      $form.trigger('form:validate:pass.ClientSideValidations');
+      dispatchCustomEvent(form, 'form:validate:pass');
     } else {
-      $form.trigger('form:validate:fail.ClientSideValidations');
+      dispatchCustomEvent(form, 'form:validate:fail');
     }
-    $form.trigger('form:validate:after.ClientSideValidations');
+    dispatchCustomEvent(form, 'form:validate:after');
     return valid;
   };
-  const passElement = $element => {
-    const element = $element[0];
-    $element.trigger('element:validate:pass.ClientSideValidations');
+  const passElement = element => {
+    dispatchCustomEvent(element, 'element:validate:pass');
     delete element.dataset.csvValid;
   };
-  const failElement = ($element, message) => {
-    const element = $element[0];
-    $element.trigger('element:validate:fail.ClientSideValidations', message);
+  const failElement = (element, message) => {
+    dispatchCustomEvent(element, 'element:validate:fail', message);
     element.dataset.csvValid = 'false';
   };
-  const afterValidate = $element => {
-    const element = $element[0];
-    $element.trigger('element:validate:after.ClientSideValidations');
+  const afterValidate = element => {
+    dispatchCustomEvent(element, 'element:validate:after');
     return element.dataset.csvValid !== 'false';
   };
-  const executeValidator = (validatorFunctions, validatorFunction, validatorOptions, $element) => {
+  const executeValidator = (validatorFunctions, validatorFunction, validatorOptions, element) => {
     for (const validatorOption in validatorOptions) {
       if (!validatorOptions[validatorOption]) {
         continue;
       }
-      const message = validatorFunction.call(validatorFunctions, $element, validatorOptions[validatorOption]);
+      const message = validatorFunction.call(validatorFunctions, element, validatorOptions[validatorOption]);
       if (message) {
-        failElement($element, message);
+        failElement(element, message);
         return false;
       }
     }
     return true;
   };
-  const executeValidators = (validatorFunctions, $element, validators) => {
+  const executeValidators = (validatorFunctions, element, validators) => {
     for (const validator in validators) {
       if (!validatorFunctions[validator]) {
         continue;
       }
-      if (!executeValidator(validatorFunctions, validatorFunctions[validator], validators[validator], $element)) {
+      if (!executeValidator(validatorFunctions, validatorFunctions[validator], validators[validator], element)) {
         return false;
       }
     }
     return true;
   };
-  const isMarkedForDestroy = $element => {
-    const element = $element[0];
+  const isMarkedForDestroy = element => {
     const elementName = element.name;
-    if (/\[([^\]]*?)\]$/.test(elementName)) {
+    const form = element.form;
+    if (form && /\[([^\]]*?)\]$/.test(elementName)) {
       const destroyInputName = elementName.replace(/\[([^\]]*?)\]$/, '[_destroy]');
-      const destroyInputElement = document.querySelector("input[name=\"".concat(destroyInputName, "\"]"));
+      const destroyInputElement = form.querySelector("input[name=\"".concat(destroyInputName, "\"]"));
       if (destroyInputElement && destroyInputElement.value === '1') {
         return true;
       }
     }
     return false;
   };
-  const executeAllValidators = ($element, validators) => {
-    const element = $element[0];
+  const executeAllValidators = (element, validators) => {
     if (element.dataset.csvChanged === 'false' || element.disabled) {
       return;
     }
     element.dataset.csvChanged = 'false';
-    if (executeValidators(ClientSideValidations.validators.all(), $element, validators)) {
-      passElement($element);
+    if (executeValidators(ClientSideValidations.validators.all(), element, validators)) {
+      passElement(element);
     }
   };
-  const validateElement = ($element, validators) => {
-    $element.trigger('element:validate:before.ClientSideValidations');
-    if (isMarkedForDestroy($element)) {
-      passElement($element);
+  const validateElement = (element, validators) => {
+    dispatchCustomEvent(element, 'element:validate:before');
+    if (isMarkedForDestroy(element)) {
+      passElement(element);
     } else {
-      executeAllValidators($element, validators);
+      executeAllValidators(element, validators);
     }
-    return afterValidate($element);
+    return afterValidate(element);
   };
   if (!window.ClientSideValidations) {
     window.ClientSideValidations = ClientSideValidations;

--- a/lib/client_side_validations/version.rb
+++ b/lib/client_side_validations/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ClientSideValidations
-  VERSION = '23.1.0'
+  VERSION = '24.0.0'
 end

--- a/package.json
+++ b/package.json
@@ -22,20 +22,17 @@
     "test": "test/javascript/run-qunit.mjs"
   },
   "devDependencies": {
-    "@babel/core": "^7.28.6",
-    "@babel/preset-env": "^7.28.6",
+    "@babel/core": "^7.29.0",
+    "@babel/preset-env": "^7.29.2",
     "@rollup/plugin-babel": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "chrome-launcher": "^1.2.1",
-    "eslint": "^9.39.2",
-    "eslint-plugin-compat": "^6.1.0",
+    "eslint": "^9.39.4",
+    "eslint-plugin-compat": "^6.2.1",
     "neostandard": "^0.12.2",
-    "puppeteer-core": "^24.36.0",
-    "rollup": "^4.57.0",
+    "puppeteer-core": "^24.40.0",
+    "rollup": "^4.60.1",
     "rollup-plugin-copy": "^3.5.0"
-  },
-  "peerDependencies": {
-    "jquery": "^3.7.1 || ^4.0.0"
   },
   "main": "dist/client-side-validations.js",
   "module": "dist/client-side-validations.esm.js",
@@ -65,7 +62,7 @@
       "/vendor/"
     ]
   },
-  "version": "23.1.0",
+  "version": "24.0.0",
   "directories": {
     "lib": "lib",
     "test": "test"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -19,16 +19,12 @@ const banner = `/*!
 export default [
   {
     input: 'src/index.js',
-    external: ['jquery'],
     output: [
       {
         file: pkg.main,
         banner,
         format: 'umd',
-        name: 'ClientSideValidations',
-        globals: {
-          jquery: 'jQuery'
-        }
+        name: 'ClientSideValidations'
       }
     ],
     plugins: [
@@ -46,7 +42,6 @@ export default [
 
   {
     input: 'src/index.js',
-    external: ['jquery'],
     output: [
       {
         file: pkg.module,

--- a/src/core.js
+++ b/src/core.js
@@ -1,149 +1,173 @@
-import jQuery from 'jquery'
-import { createElementFromHTML } from './utils'
+import { bindElementEvents, clearBoundEventListeners } from './events'
+import { createElementFromHTML, getDOMElements, isFormElement, isInputElement, isVisible } from './utils'
+
+const isNamedInputElement = (element) => {
+  return isInputElement(element) && element.name != null && element.name !== ''
+}
+
+const getFormControls = (form) => {
+  return Array.from(form.elements).filter(isInputElement)
+}
+
+const getFormInputs = (form) => {
+  return getFormControls(form).filter((element) => {
+    return isNamedInputElement(element) && !element.disabled && isVisible(element)
+  })
+}
+
+const findFormElementByName = (form, name) => {
+  return getFormControls(form).find((element) => element.name === name)
+}
+
+const enableForm = (form) => {
+  ClientSideValidations.enablers.form(form)
+}
+
+const enableForms = () => {
+  document.querySelectorAll(ClientSideValidations.selectors.forms).forEach(enableForm)
+}
 
 const ClientSideValidations = {
   callbacks: {
     element: {
-      after: ($element, eventData) => {},
-      before: ($element, eventData) => {},
-      fail: ($element, message, addError, eventData) => addError(),
-      pass: ($element, removeError, eventData) => removeError()
+      after: (element, eventData) => {},
+      before: (element, eventData) => {},
+      fail: (element, message, addError, eventData) => addError(),
+      pass: (element, removeError, eventData) => removeError()
     },
     form: {
-      after: ($form, eventData) => {},
-      before: ($form, eventData) => {},
-      fail: ($form, eventData) => {},
-      pass: ($form, eventData) => {}
+      after: (form, eventData) => {},
+      before: (form, eventData) => {},
+      fail: (form, eventData) => {},
+      pass: (form, eventData) => {}
     }
   },
   eventsToBind: {
-    form: (form, $form) => ({
-      'submit.ClientSideValidations': (eventData) => {
-        if (!$form.isValid(form.ClientSideValidations.settings.validators)) {
+    form: (form) => ({
+      submit: (eventData) => {
+        if (!ClientSideValidations.isValid(form, form.ClientSideValidations.settings.validators)) {
           eventData.preventDefault()
           eventData.stopImmediatePropagation()
         }
       },
-      'ajax:beforeSend.ClientSideValidations': function (eventData) {
+      'ajax:beforeSend': function (eventData) {
         if (eventData.target === this) {
-          $form.isValid(form.ClientSideValidations.settings.validators)
+          ClientSideValidations.isValid(form, form.ClientSideValidations.settings.validators)
         }
       },
-      'form:validate:after.ClientSideValidations': (eventData) => {
-        ClientSideValidations.callbacks.form.after($form, eventData)
+      'form:validate:after': (eventData) => {
+        ClientSideValidations.callbacks.form.after(form, eventData)
       },
-      'form:validate:before.ClientSideValidations': (eventData) => {
-        ClientSideValidations.callbacks.form.before($form, eventData)
+      'form:validate:before': (eventData) => {
+        ClientSideValidations.callbacks.form.before(form, eventData)
       },
-      'form:validate:fail.ClientSideValidations': (eventData) => {
-        ClientSideValidations.callbacks.form.fail($form, eventData)
+      'form:validate:fail': (eventData) => {
+        ClientSideValidations.callbacks.form.fail(form, eventData)
       },
-      'form:validate:pass.ClientSideValidations': (eventData) => {
-        ClientSideValidations.callbacks.form.pass($form, eventData)
+      'form:validate:pass': (eventData) => {
+        ClientSideValidations.callbacks.form.pass(form, eventData)
       }
     }),
     input: (form) => ({
-      'focusout.ClientSideValidations': function () {
-        jQuery(this).isValid(form.ClientSideValidations.settings.validators)
+      focusout: function () {
+        ClientSideValidations.isValid(this, form.ClientSideValidations.settings.validators)
       },
-      'change.ClientSideValidations': function () {
+      change: function () {
         this.dataset.csvChanged = 'true'
       },
-      'element:validate:after.ClientSideValidations': function (eventData) {
-        ClientSideValidations.callbacks.element.after(jQuery(this), eventData)
+      'element:validate:after': function (eventData) {
+        ClientSideValidations.callbacks.element.after(this, eventData)
       },
-      'element:validate:before.ClientSideValidations': function (eventData) {
-        ClientSideValidations.callbacks.element.before(jQuery(this), eventData)
+      'element:validate:before': function (eventData) {
+        ClientSideValidations.callbacks.element.before(this, eventData)
       },
-      'element:validate:fail.ClientSideValidations': function (eventData, message) {
-        const $element = jQuery(this)
+      'element:validate:fail': function (eventData) {
+        const element = this
+        const message = eventData.detail
 
-        ClientSideValidations.callbacks.element.fail($element, message, function () {
-          form.ClientSideValidations.addError($element, message)
+        ClientSideValidations.callbacks.element.fail(element, message, function () {
+          form.ClientSideValidations.addError(element, message)
         }, eventData)
       },
-      'element:validate:pass.ClientSideValidations': function (eventData) {
-        const $element = jQuery(this)
+      'element:validate:pass': function (eventData) {
+        const element = this
 
-        ClientSideValidations.callbacks.element.pass($element, function () {
-          form.ClientSideValidations.removeError($element)
+        ClientSideValidations.callbacks.element.pass(element, function () {
+          form.ClientSideValidations.removeError(element)
         }, eventData)
       }
     }),
-    inputConfirmation: ($element, form) => ({
-      'focusout.ClientSideValidations': () => {
-        $element[0].dataset.csvChanged = 'true'
-        $element.isValid(form.ClientSideValidations.settings.validators)
+    inputConfirmation: (elementToConfirm, form) => ({
+      focusout: () => {
+        elementToConfirm.dataset.csvChanged = 'true'
+        ClientSideValidations.isValid(elementToConfirm, form.ClientSideValidations.settings.validators)
       },
-      'keyup.ClientSideValidations': () => {
-        $element[0].dataset.csvChanged = 'true'
-        $element.isValid(form.ClientSideValidations.settings.validators)
+      keyup: () => {
+        elementToConfirm.dataset.csvChanged = 'true'
+        ClientSideValidations.isValid(elementToConfirm, form.ClientSideValidations.settings.validators)
       }
     })
   },
   enablers: {
     form: (form) => {
-      const $form = jQuery(form)
+      clearBoundEventListeners(form)
+      getFormControls(form).forEach(clearBoundEventListeners)
 
       form.ClientSideValidations = {
         settings: JSON.parse(form.dataset.clientSideValidations),
-        addError: ($element, message) => ClientSideValidations
+        addError: (element, message) => ClientSideValidations
           .formBuilders[form.ClientSideValidations.settings.html_settings.type]
-          .add($element, form.ClientSideValidations.settings.html_settings, message),
-        removeError: ($element) => ClientSideValidations
+          .add(element, form.ClientSideValidations.settings.html_settings, message),
+        removeError: (element) => ClientSideValidations
           .formBuilders[form.ClientSideValidations.settings.html_settings.type]
-          .remove($element, form.ClientSideValidations.settings.html_settings)
+          .remove(element, form.ClientSideValidations.settings.html_settings)
       }
 
-      const eventsToBind = ClientSideValidations.eventsToBind.form(form, $form)
+      bindElementEvents(form, ClientSideValidations.eventsToBind.form(form))
 
-      for (const eventName in eventsToBind) {
-        const eventFunction = eventsToBind[eventName]
-        $form.on(eventName, eventFunction)
-      }
-
-      $form.find(ClientSideValidations.selectors.inputs).each(function () {
-        ClientSideValidations.enablers.input(this)
+      getFormInputs(form).forEach((element) => {
+        ClientSideValidations.enablers.input(element)
       })
     },
     input: function (input) {
-      const $input = jQuery(input)
       const form = input.form
-      const $form = jQuery(form)
+
+      if (!form) {
+        return
+      }
+
+      clearBoundEventListeners(input)
 
       const eventsToBind = ClientSideValidations.eventsToBind.input(form)
 
-      for (const eventName in eventsToBind) {
-        const eventFunction = eventsToBind[eventName]
-
-        $input.filter(':not(:radio):not([id$=_confirmation])').each(function () {
-          this.dataset.csvValidate = 'true'
-        }).on(eventName, eventFunction)
+      if (input.type !== 'radio' && !(input.id && input.id.endsWith('_confirmation'))) {
+        input.dataset.csvValidate = 'true'
+        bindElementEvents(input, eventsToBind)
       }
 
-      $input.filter(':checkbox').on('change.ClientSideValidations', function () {
-        jQuery(this).isValid(form.ClientSideValidations.settings.validators)
-      })
-
-      $input.filter('[id$=_confirmation]').each(function () {
-        const $element = jQuery(this)
-        const $elementToConfirm = $form.find(`#${this.id.match(/(.+)_confirmation/)[1]}:input`)
-
-        if ($elementToConfirm.length) {
-          const eventsToBind = ClientSideValidations.eventsToBind.inputConfirmation($elementToConfirm, form)
-
-          for (const eventName in eventsToBind) {
-            const eventFunction = eventsToBind[eventName]
-            jQuery(`#${$element.attr('id')}`).on(eventName, eventFunction)
+      if (input.type === 'checkbox') {
+        bindElementEvents(input, {
+          change: function () {
+            ClientSideValidations.isValid(this, form.ClientSideValidations.settings.validators)
           }
+        })
+      }
+
+      if (input.id && input.id.endsWith('_confirmation')) {
+        const elementToConfirm = document.getElementById(input.id.match(/(.+)_confirmation/)[1])
+
+        if (elementToConfirm && elementToConfirm.form === form) {
+          bindElementEvents(input, ClientSideValidations.eventsToBind.inputConfirmation(elementToConfirm, form))
         }
-      })
+      }
     }
   },
   formBuilders: {
     'ActionView::Helpers::FormBuilder': {
-      add: ($element, settings, message) => {
-        const element = $element[0]
+      add: (element, settings, message) => {
+        if (!element) {
+          return
+        }
 
         const form = element.form
 
@@ -185,8 +209,10 @@ const ClientSideValidations = {
           labelMessageElement.textContent = message
         }
       },
-      remove: ($element, settings) => {
-        const element = $element[0]
+      remove: (element, settings) => {
+        if (!element) {
+          return
+        }
 
         const form = element.form
 
@@ -224,8 +250,8 @@ const ClientSideValidations = {
     }
   },
   selectors: {
-    inputs: ':input:not(button):not([type="submit"])[name]:visible:enabled',
-    validate_inputs: ':input:enabled:visible[data-csv-validate]',
+    inputs: 'input:not([type="submit"]):not([type="button"])[name], select[name], textarea[name]',
+    validate_inputs: 'input[data-csv-validate]:not([type="submit"]):not([type="button"]), select[data-csv-validate], textarea[data-csv-validate]',
     forms: 'form[data-client-side-validations]'
   },
   validators: {
@@ -239,27 +265,37 @@ const ClientSideValidations = {
     remote: {}
   },
   disable: (target) => {
-    const $target = jQuery(target)
+    getDOMElements(target).forEach((element) => {
+      clearBoundEventListeners(element)
 
-    $target.off('.ClientSideValidations')
+      if (isFormElement(element)) {
+        getFormControls(element).forEach((input) => {
+          clearBoundEventListeners(input)
+          delete input.dataset.csvValid
+          delete input.dataset.csvChanged
+          delete input.dataset.csvValidate
+        })
 
-    if ($target.is('form')) {
-      ClientSideValidations.disable($target.find(':input'))
-    } else {
-      delete $target[0].dataset.csvValid
-      delete $target[0].dataset.csvChanged
-      $target.filter(':input').each(function () {
-        delete this.dataset.csvValidate
-      })
-    }
+        return
+      }
+
+      delete element.dataset.csvValid
+      delete element.dataset.csvChanged
+
+      if (isInputElement(element)) {
+        delete element.dataset.csvValidate
+      }
+    })
   },
   reset: (form) => {
-    const $form = jQuery(form)
-
     ClientSideValidations.disable(form)
 
     for (const key in form.ClientSideValidations.settings.validators) {
-      form.ClientSideValidations.removeError($form.find(`[name="${key}"]`))
+      const element = findFormElementByName(form, key)
+
+      if (element) {
+        form.ClientSideValidations.removeError(element)
+      }
     }
 
     ClientSideValidations.enablers.form(form)
@@ -275,9 +311,11 @@ const ClientSideValidations = {
     const initializeOnEvent = ClientSideValidations.initializeOnEvent()
 
     if (initializeOnEvent != null) {
-      jQuery(document).on(initializeOnEvent, () => jQuery(ClientSideValidations.selectors.forms).validate())
+      document.addEventListener(initializeOnEvent, enableForms)
+    } else if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', enableForms, { once: true })
     } else {
-      jQuery(() => jQuery(ClientSideValidations.selectors.forms).validate())
+      enableForms()
     }
   }
 }

--- a/src/events.js
+++ b/src/events.js
@@ -1,0 +1,42 @@
+const boundEventListeners = new WeakMap()
+
+const addBoundEventListener = (element, eventName, listener) => {
+  element.addEventListener(eventName, listener)
+
+  const listeners = boundEventListeners.get(element) || []
+  listeners.push({ eventName, listener })
+  boundEventListeners.set(element, listeners)
+}
+
+export const bindElementEvents = (element, eventsToBind) => {
+  for (const eventName in eventsToBind) {
+    addBoundEventListener(element, eventName, eventsToBind[eventName])
+  }
+}
+
+export const clearBoundEventListeners = (element) => {
+  const listeners = boundEventListeners.get(element)
+
+  if (!listeners) {
+    return
+  }
+
+  listeners.forEach(({ eventName, listener }) => {
+    element.removeEventListener(eventName, listener)
+  })
+
+  boundEventListeners.delete(element)
+}
+
+export const dispatchCustomEvent = (element, eventName, detail) => {
+  element.dispatchEvent(new CustomEvent(eventName, {
+    bubbles: true,
+    detail
+  }))
+}
+
+export default {
+  bindElementEvents,
+  clearBoundEventListeners,
+  dispatchCustomEvent
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
-import jQuery from 'jquery'
 import ClientSideValidations from './core'
+import { dispatchCustomEvent } from './events'
+import { getDOMElements, isFormElement, isInputElement, isVisible } from './utils'
 
 import { absenceLocalValidator, presenceLocalValidator } from './validators/local/absence_presence'
 import { acceptanceLocalValidator } from './validators/local/acceptance'
@@ -24,50 +25,45 @@ ClientSideValidations.validators.local = {
   uniqueness: uniquenessLocalValidator
 }
 
-jQuery.fn.disableClientSideValidations = function () {
-  ClientSideValidations.disable(this)
-
-  return this
-}
-
-jQuery.fn.enableClientSideValidations = function () {
-  const selectors = { forms: 'form', inputs: 'input' }
-
-  for (const selector in selectors) {
-    const enablers = selectors[selector]
-
-    this.filter(ClientSideValidations.selectors[selector]).each(function () {
-      ClientSideValidations.enablers[enablers](this)
-    })
-  }
-
-  return this
-}
-
-jQuery.fn.resetClientSideValidations = function () {
-  this.filter(ClientSideValidations.selectors.forms).each(function () {
-    ClientSideValidations.reset(this)
+ClientSideValidations.enable = (target) => {
+  getDOMElements(target).forEach((element) => {
+    if (isFormElement(element)) {
+      ClientSideValidations.enablers.form(element)
+    } else if (isInputElement(element)) {
+      ClientSideValidations.enablers.input(element)
+    }
   })
 
-  return this
+  return target
 }
 
-jQuery.fn.validate = function () {
-  this.filter(ClientSideValidations.selectors.forms).each(function () {
-    jQuery(this).enableClientSideValidations()
+ClientSideValidations.validate = (target) => {
+  getDOMElements(target).forEach((element) => {
+    if (isFormElement(element)) {
+      ClientSideValidations.enable(element)
+    }
   })
 
-  return this
+  return target
 }
 
-jQuery.fn.isValid = function (validators) {
-  const obj = jQuery(this[0])
+ClientSideValidations.isValid = (target, validators) => {
+  const element = getDOMElements(target)[0]
 
-  if (obj.is('form')) {
-    return validateForm(obj, validators)
-  } else {
-    return validateElement(obj, validatorsFor(this[0].name, validators))
+  if (!element) {
+    return true
   }
+
+  if (!validators) {
+    const form = isFormElement(element) ? element : element.form
+    validators = form?.ClientSideValidations?.settings?.validators
+  }
+
+  if (isFormElement(element)) {
+    return validateForm(element, validators || {})
+  }
+
+  return validateElement(element, validatorsFor(element.name, validators || {}))
 }
 
 const cleanNestedElementName = (elementName, nestedMatches, validators) => {
@@ -93,6 +89,10 @@ const cleanElementName = (elementName, validators) => {
 }
 
 const validatorsFor = (elementName, validators) => {
+  if (!elementName || !validators) {
+    return {}
+  }
+
   if (Object.prototype.hasOwnProperty.call(validators, elementName)) {
     return validators[elementName]
   }
@@ -100,58 +100,63 @@ const validatorsFor = (elementName, validators) => {
   return validators[cleanElementName(elementName, validators)] || {}
 }
 
-const validateForm = ($form, validators) => {
-  let valid = true
-
-  $form.trigger('form:validate:before.ClientSideValidations')
-
-  $form.find(ClientSideValidations.selectors.validate_inputs).each(function () {
-    if (!jQuery(this).isValid(validators)) {
-      valid = false
+const getValidationInputs = (form) => {
+  return Array.from(form.elements).filter((element) => {
+    if (element.dataset.csvValidate == null || element.disabled) {
+      return false
     }
 
-    return true
+    return isVisible(element)
+  })
+}
+
+const validateForm = (form, validators) => {
+  let valid = true
+
+  dispatchCustomEvent(form, 'form:validate:before')
+
+  getValidationInputs(form).forEach((element) => {
+    if (!validateElement(element, validatorsFor(element.name, validators))) {
+      valid = false
+    }
   })
 
   if (valid) {
-    $form.trigger('form:validate:pass.ClientSideValidations')
+    dispatchCustomEvent(form, 'form:validate:pass')
   } else {
-    $form.trigger('form:validate:fail.ClientSideValidations')
+    dispatchCustomEvent(form, 'form:validate:fail')
   }
 
-  $form.trigger('form:validate:after.ClientSideValidations')
+  dispatchCustomEvent(form, 'form:validate:after')
 
   return valid
 }
 
-const passElement = ($element) => {
-  const element = $element[0]
-  $element.trigger('element:validate:pass.ClientSideValidations')
+const passElement = (element) => {
+  dispatchCustomEvent(element, 'element:validate:pass')
   delete element.dataset.csvValid
 }
 
-const failElement = ($element, message) => {
-  const element = $element[0]
-  $element.trigger('element:validate:fail.ClientSideValidations', message)
+const failElement = (element, message) => {
+  dispatchCustomEvent(element, 'element:validate:fail', message)
   element.dataset.csvValid = 'false'
 }
 
-const afterValidate = ($element) => {
-  const element = $element[0]
-  $element.trigger('element:validate:after.ClientSideValidations')
+const afterValidate = (element) => {
+  dispatchCustomEvent(element, 'element:validate:after')
   return element.dataset.csvValid !== 'false'
 }
 
-const executeValidator = (validatorFunctions, validatorFunction, validatorOptions, $element) => {
+const executeValidator = (validatorFunctions, validatorFunction, validatorOptions, element) => {
   for (const validatorOption in validatorOptions) {
     if (!validatorOptions[validatorOption]) {
       continue
     }
 
-    const message = validatorFunction.call(validatorFunctions, $element, validatorOptions[validatorOption])
+    const message = validatorFunction.call(validatorFunctions, element, validatorOptions[validatorOption])
 
     if (message) {
-      failElement($element, message)
+      failElement(element, message)
       return false
     }
   }
@@ -159,13 +164,13 @@ const executeValidator = (validatorFunctions, validatorFunction, validatorOption
   return true
 }
 
-const executeValidators = (validatorFunctions, $element, validators) => {
+const executeValidators = (validatorFunctions, element, validators) => {
   for (const validator in validators) {
     if (!validatorFunctions[validator]) {
       continue
     }
 
-    if (!executeValidator(validatorFunctions, validatorFunctions[validator], validators[validator], $element)) {
+    if (!executeValidator(validatorFunctions, validatorFunctions[validator], validators[validator], element)) {
       return false
     }
   }
@@ -173,13 +178,13 @@ const executeValidators = (validatorFunctions, $element, validators) => {
   return true
 }
 
-const isMarkedForDestroy = ($element) => {
-  const element = $element[0]
+const isMarkedForDestroy = (element) => {
   const elementName = element.name
+  const form = element.form
 
-  if (/\[([^\]]*?)\]$/.test(elementName)) {
+  if (form && /\[([^\]]*?)\]$/.test(elementName)) {
     const destroyInputName = elementName.replace(/\[([^\]]*?)\]$/, '[_destroy]')
-    const destroyInputElement = document.querySelector(`input[name="${destroyInputName}"]`)
+    const destroyInputElement = form.querySelector(`input[name="${destroyInputName}"]`)
 
     if (destroyInputElement && destroyInputElement.value === '1') {
       return true
@@ -189,29 +194,28 @@ const isMarkedForDestroy = ($element) => {
   return false
 }
 
-const executeAllValidators = ($element, validators) => {
-  const element = $element[0]
+const executeAllValidators = (element, validators) => {
   if (element.dataset.csvChanged === 'false' || element.disabled) {
     return
   }
 
   element.dataset.csvChanged = 'false'
 
-  if (executeValidators(ClientSideValidations.validators.all(), $element, validators)) {
-    passElement($element)
+  if (executeValidators(ClientSideValidations.validators.all(), element, validators)) {
+    passElement(element)
   }
 }
 
-const validateElement = ($element, validators) => {
-  $element.trigger('element:validate:before.ClientSideValidations')
+const validateElement = (element, validators) => {
+  dispatchCustomEvent(element, 'element:validate:before')
 
-  if (isMarkedForDestroy($element)) {
-    passElement($element)
+  if (isMarkedForDestroy(element)) {
+    passElement(element)
   } else {
-    executeAllValidators($element, validators)
+    executeAllValidators(element, validators)
   }
 
-  return afterValidate($element)
+  return afterValidate(element)
 }
 
 if (!window.ClientSideValidations) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,6 +21,53 @@ export const createElementFromHTML = (html) => {
   return element.firstChild
 }
 
+const isDOMCollection = (target) => {
+  return Array.isArray(target) ||
+    (typeof NodeList !== 'undefined' && target instanceof NodeList) ||
+    (typeof HTMLCollection !== 'undefined' && target instanceof HTMLCollection) ||
+    (typeof RadioNodeList !== 'undefined' && target instanceof RadioNodeList)
+}
+
+const isDOMElement = (target) => {
+  return target != null && target.nodeType === 1
+}
+
+export const getDOMElements = (target) => {
+  if (target == null) {
+    return []
+  }
+
+  if (isDOMElement(target)) {
+    return [target]
+  }
+
+  if (isDOMCollection(target)) {
+    return Array.from(target).filter(isDOMElement)
+  }
+
+  return []
+}
+
+export const isFormElement = (element) => {
+  return element.tagName === 'FORM'
+}
+
+export const isInputElement = (element) => {
+  switch (element.tagName) {
+    case 'INPUT':
+      return element.type !== 'submit' && element.type !== 'button'
+    case 'SELECT':
+    case 'TEXTAREA':
+      return true
+    default:
+      return false
+  }
+}
+
+export const isVisible = (element) => {
+  return Boolean(element.offsetWidth || element.offsetHeight || element.getClientRects().length)
+}
+
 export const isValuePresent = (value) => {
   return !/^\s*$/.test(value || '')
 }
@@ -35,6 +82,10 @@ export default {
   addClass,
   arrayHasValue,
   createElementFromHTML,
+  getDOMElements,
+  isFormElement,
+  isInputElement,
+  isVisible,
   isValuePresent,
   removeClass
 }

--- a/src/validators/local/absence_presence.js
+++ b/src/validators/local/absence_presence.js
@@ -1,16 +1,12 @@
 import { isValuePresent } from '../../utils'
 
-export const absenceLocalValidator = ($element, options) => {
-  const element = $element[0]
-
+export const absenceLocalValidator = (element, options) => {
   if (isValuePresent(element.value)) {
     return options.message
   }
 }
 
-export const presenceLocalValidator = ($element, options) => {
-  const element = $element[0]
-
+export const presenceLocalValidator = (element, options) => {
   if (!isValuePresent(element.value)) {
     return options.message
   }

--- a/src/validators/local/acceptance.js
+++ b/src/validators/local/acceptance.js
@@ -14,8 +14,7 @@ const isTextAccepted = (value, acceptOption) => {
   return value === acceptOption
 }
 
-export const acceptanceLocalValidator = ($element, options) => {
-  const element = $element[0]
+export const acceptanceLocalValidator = (element, options) => {
   let valid = true
 
   if (element.type === 'checkbox') {

--- a/src/validators/local/confirmation.js
+++ b/src/validators/local/confirmation.js
@@ -1,5 +1,4 @@
-export const confirmationLocalValidator = ($element, options) => {
-  const element = $element[0]
+export const confirmationLocalValidator = (element, options) => {
   let value = element.value
   let confirmationValue = document.getElementById(`${element.id}_confirmation`).value
 

--- a/src/validators/local/exclusion_inclusion.js
+++ b/src/validators/local/exclusion_inclusion.js
@@ -22,8 +22,7 @@ const isIncluded = (value, options, allowBlank) => {
   return (options.in && isInList(value, options.in)) || (options.range && isInRange(value, options.range))
 }
 
-export const exclusionLocalValidator = ($element, options) => {
-  const element = $element[0]
+export const exclusionLocalValidator = (element, options) => {
   const value = element.value
 
   if (isIncluded(value, options, false) || (!options.allow_blank && !isValuePresent(value))) {
@@ -31,8 +30,7 @@ export const exclusionLocalValidator = ($element, options) => {
   }
 }
 
-export const inclusionLocalValidator = ($element, options) => {
-  const element = $element[0]
+export const inclusionLocalValidator = (element, options) => {
   const value = element.value
 
   if (!isIncluded(value, options, true)) {

--- a/src/validators/local/format.js
+++ b/src/validators/local/format.js
@@ -8,8 +8,7 @@ const hasValidFormat = (value, withOptions, withoutOptions) => {
   return (withOptions && isMatching(value, withOptions)) || (withoutOptions && !isMatching(value, withoutOptions))
 }
 
-export const formatLocalValidator = ($element, options) => {
-  const element = $element[0]
+export const formatLocalValidator = (element, options) => {
   const value = element.value
 
   if (options.allow_blank && !isValuePresent(value)) {

--- a/src/validators/local/length.js
+++ b/src/validators/local/length.js
@@ -23,8 +23,7 @@ const runValidations = (valueLength, options) => {
   }
 }
 
-export const lengthLocalValidator = ($element, options) => {
-  const element = $element[0]
+export const lengthLocalValidator = (element, options) => {
   const value = element.value
 
   if (options.allow_blank && !isValuePresent(value)) {

--- a/src/validators/local/numericality.js
+++ b/src/validators/local/numericality.js
@@ -89,8 +89,7 @@ const runValidations = (formattedValue, form, options) => {
   return runFunctionValidations(formattedValue, form, options)
 }
 
-export const numericalityLocalValidator = ($element, options) => {
-  const element = $element[0]
+export const numericalityLocalValidator = (element, options) => {
   const value = element.value
 
   if (options.allow_blank && !isValuePresent(value)) {

--- a/src/validators/local/uniqueness.js
+++ b/src/validators/local/uniqueness.js
@@ -5,20 +5,19 @@ const isLocallyUnique = (element, value, otherValue, caseSensitive) => {
   }
 
   if (otherValue === value) {
-    element.dataset.notLocallyUnique = true
+    element.dataset.csvNotLocallyUnique = 'true'
     return false
   }
 
-  if (element.dataset.notLocallyUnique) {
-    delete element.dataset.notLocallyUnique
-    element.dataset.changed = true
+  if (element.dataset.csvNotLocallyUnique) {
+    delete element.dataset.csvNotLocallyUnique
+    element.dataset.csvChanged = 'true'
   }
 
   return true
 }
 
-export const uniquenessLocalValidator = ($element, options) => {
-  const element = $element[0]
+export const uniquenessLocalValidator = (element, options) => {
   const elementName = element.name
   const matches = elementName.match(/^(.+_attributes\])\[\d+\](.+)$/)
 

--- a/test/javascript/public/test/callbacks/elementAfter.js
+++ b/test/javascript/public/test/callbacks/elementAfter.js
@@ -1,6 +1,11 @@
 QUnit.module('Element Validate After Callback', {
   beforeEach: function () {
-    dataCsv = {
+    var fixture = document.getElementById('qunit-fixture')
+    var result = document.createElement('span')
+    var form = document.createElement('form')
+    var input = document.createElement('input')
+    var label = document.createElement('label')
+    var dataCsv = {
       html_settings: {
         type: 'ActionView::Helpers::FormBuilder',
         input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
@@ -9,48 +14,48 @@ QUnit.module('Element Validate After Callback', {
       validators: { 'user[name]': { presence: [{ message: 'must be present' }] } }
     }
 
-    $('#qunit-fixture')
-      .append($('<span id="result">'))
-      .append($('<form>', {
-        action: '/users',
-        'data-client-side-validations': JSON.stringify(dataCsv),
-        method: 'post',
-        id: 'new_user'
-      }))
-      .find('form')
-      .append($('<input />', {
-        name: 'user[name]',
-        id: 'user_name',
-        type: 'text'
-      }))
-      .append($('<label for="user_name">Name</label>'))
+    result.id = 'result'
+    form.action = '/users'
+    form.dataset.clientSideValidations = JSON.stringify(dataCsv)
+    form.method = 'post'
+    form.id = 'new_user'
+    input.name = 'user[name]'
+    input.id = 'user_name'
+    input.type = 'text'
+    label.htmlFor = 'user_name'
+    label.textContent = 'Name'
 
-    ClientSideValidations.callbacks.element.after = function (element, message) {
-      $('#result').text('Element Validate After ' + element.attr('id'))
+    form.appendChild(input)
+    form.appendChild(label)
+    fixture.appendChild(result)
+    fixture.appendChild(form)
+
+    ClientSideValidations.callbacks.element.after = function (element) {
+      document.getElementById('result').textContent = 'Element Validate After ' + element.id
     }
-    $('form#new_user').validate()
+    ClientSideValidations.validate(form)
   },
 
   afterEach: function () {
     ClientSideValidations.callbacks.element.after = function (element, eventData) {}
+    document.getElementById('qunit-fixture').replaceChildren()
   }
 })
 
 QUnit.test('runs callback when form element validate', function (assert) {
-  var input = $('#user_name')
+  var input = document.getElementById('user_name')
 
-  assert.equal($('#result').text(), '')
+  assert.equal(document.getElementById('result').textContent, '')
 
-  input.trigger('focusout')
-  assert.equal($('#result').text(), 'Element Validate After user_name')
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.equal(document.getElementById('result').textContent, 'Element Validate After user_name')
 })
 
 QUnit.test('runs callback when form validates', function (assert) {
-  var form = $('#new_user')
-  var input = form.find('input')
+  var form = document.getElementById('new_user')
 
-  assert.equal($('#result').text(), '')
+  assert.equal(document.getElementById('result').textContent, '')
 
-  form.submit()
-  assert.equal($('#result').text(), 'Element Validate After user_name')
+  form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+  assert.equal(document.getElementById('result').textContent, 'Element Validate After user_name')
 })

--- a/test/javascript/public/test/callbacks/elementBefore.js
+++ b/test/javascript/public/test/callbacks/elementBefore.js
@@ -1,55 +1,60 @@
 QUnit.module('Element Validate Before Callback', {
   beforeEach: function () {
-    dataCsv = {
+    var fixture = document.getElementById('qunit-fixture')
+    var result = document.createElement('span')
+    var form = document.createElement('form')
+    var input = document.createElement('input')
+    var label = document.createElement('label')
+    var dataCsv = {
       html_settings: {
         type: 'ActionView::Helpers::FormBuilder',
         input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
         label_tag: '<div class="field_with_errors"><label id="label_tag"></label></div>'
       },
-      validators: { 'user[name]': { '{presence': [{ message: 'must be present' }] } }
+      validators: { 'user[name]': { presence: [{ message: 'must be present' }] } }
     }
 
-    $('#qunit-fixture')
-      .append($('<span id="result">'))
-      .append($('<form>', {
-        action: '/users',
-        'data-client-side-validations': JSON.stringify(dataCsv),
-        method: 'post',
-        id: 'new_user'
-      }))
-      .find('form')
-      .append($('<input />', {
-        name: 'user[name]',
-        id: 'user_name',
-        type: 'text'
-      }))
-      .append($('<label for="user_name">Name</label>'))
+    result.id = 'result'
+    form.action = '/users'
+    form.dataset.clientSideValidations = JSON.stringify(dataCsv)
+    form.method = 'post'
+    form.id = 'new_user'
+    input.name = 'user[name]'
+    input.id = 'user_name'
+    input.type = 'text'
+    label.htmlFor = 'user_name'
+    label.textContent = 'Name'
+
+    form.appendChild(input)
+    form.appendChild(label)
+    fixture.appendChild(result)
+    fixture.appendChild(form)
 
     ClientSideValidations.callbacks.element.before = function (element) {
-      $('#result').text('Element Validate Before ' + element.attr('id'))
+      document.getElementById('result').textContent = 'Element Validate Before ' + element.id
     }
-    $('form#new_user').validate()
+    ClientSideValidations.validate(form)
   },
   afterEach: function () {
     ClientSideValidations.callbacks.element.before = function (element, eventData) {}
+    document.getElementById('qunit-fixture').replaceChildren()
   }
 })
 
 QUnit.test('runs callback when form element validate', function (assert) {
-  var input = $('#user_name')
+  var input = document.getElementById('user_name')
 
-  assert.equal($('#result').text(), '')
+  assert.equal(document.getElementById('result').textContent, '')
 
-  input.trigger('focusout')
-  assert.equal($('#result').text(), 'Element Validate Before user_name')
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.equal(document.getElementById('result').textContent, 'Element Validate Before user_name')
 })
 
 QUnit.test('runs callback when form validates', function (assert) {
-  var form = $('#new_user')
-  var input = form.find('input')
+  var form = document.getElementById('new_user')
 
-  assert.equal($('#result').text(), '')
+  assert.equal(document.getElementById('result').textContent, '')
 
-  form.submit()
-  assert.equal($('#result').text(), 'Element Validate Before user_name')
+  form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+  assert.equal(document.getElementById('result').textContent, 'Element Validate Before user_name')
 })

--- a/test/javascript/public/test/callbacks/elementFail.js
+++ b/test/javascript/public/test/callbacks/elementFail.js
@@ -1,6 +1,11 @@
 QUnit.module('Element Validate Fail Callback', {
   beforeEach: function () {
-    dataCsv = {
+    var fixture = document.getElementById('qunit-fixture')
+    var result = document.createElement('span')
+    var form = document.createElement('form')
+    var input = document.createElement('input')
+    var label = document.createElement('label')
+    var dataCsv = {
       html_settings: {
         type: 'ActionView::Helpers::FormBuilder',
         input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
@@ -9,63 +14,64 @@ QUnit.module('Element Validate Fail Callback', {
       validators: { 'user[name]': { presence: [{ message: 'must be present' }] } }
     }
 
-    $('#qunit-fixture')
-      .append($('<span id="result">'))
-      .append($('<form>', {
-        action: '/users',
-        'data-client-side-validations': JSON.stringify(dataCsv),
-        method: 'post',
-        id: 'new_user'
-      }))
-      .find('form')
-      .append($('<input />', {
-        name: 'user[name]',
-        id: 'user_name',
-        type: 'text'
-      }))
-      .append($('<label for="user_name">Name</label>'))
+    result.id = 'result'
+    form.action = '/users'
+    form.dataset.clientSideValidations = JSON.stringify(dataCsv)
+    form.method = 'post'
+    form.id = 'new_user'
+    input.name = 'user[name]'
+    input.id = 'user_name'
+    input.type = 'text'
+    label.htmlFor = 'user_name'
+    label.textContent = 'Name'
+
+    form.appendChild(input)
+    form.appendChild(label)
+    fixture.appendChild(result)
+    fixture.appendChild(form)
 
     ClientSideValidations.callbacks.element.fail = function (element, message) {
-      $('#result').text('Element Validate Fail ' + element.attr('id') + ' ' + message)
+      document.getElementById('result').textContent = 'Element Validate Fail ' + element.id + ' ' + message
     }
-    $('form#new_user').validate()
+    ClientSideValidations.validate(form)
   },
   afterEach: function () {
     ClientSideValidations.callbacks.element.fail = function (element, message, callback) { callback() }
+    document.getElementById('qunit-fixture').replaceChildren()
   }
 })
 
 QUnit.test('runs callback when form element validate', function (assert) {
-  var input = $('#user_name')
+  var input = document.getElementById('user_name')
 
-  assert.equal($('#result').text(), '')
+  assert.equal(document.getElementById('result').textContent, '')
 
-  input.val('test')
-  input.trigger('change')
-  input.trigger('focusout')
-  assert.equal($('#result').text(), '')
+  input.value = 'test'
+  input.dispatchEvent(new Event('change', { bubbles: true }))
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.equal(document.getElementById('result').textContent, '')
 
-  input.val('')
-  input.trigger('change')
-  input.trigger('focusout')
-  assert.equal($('#result').text(), 'Element Validate Fail user_name must be present')
+  input.value = ''
+  input.dispatchEvent(new Event('change', { bubbles: true }))
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.equal(document.getElementById('result').textContent, 'Element Validate Fail user_name must be present')
 })
 
 QUnit.test('runs callback when form validates', function (assert) {
-  var form = $('#new_user')
-  var input = form.find('input')
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_name')
 
-  assert.equal($('#result').text(), '')
+  assert.equal(document.getElementById('result').textContent, '')
 
-  input.val('test')
-  input.trigger('change')
-  form.trigger('submit')
+  input.value = 'test'
+  input.dispatchEvent(new Event('change', { bubbles: true }))
+  form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
 
-  assert.equal($('#result').text(), '')
+  assert.equal(document.getElementById('result').textContent, '')
 
-  input.val('')
-  input.trigger('change')
-  form.trigger('submit')
+  input.value = ''
+  input.dispatchEvent(new Event('change', { bubbles: true }))
+  form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
 
-  assert.equal($('#result').text(), 'Element Validate Fail user_name must be present')
+  assert.equal(document.getElementById('result').textContent, 'Element Validate Fail user_name must be present')
 })

--- a/test/javascript/public/test/callbacks/elementPass.js
+++ b/test/javascript/public/test/callbacks/elementPass.js
@@ -1,6 +1,11 @@
 QUnit.module('Element Validate Pass Callback', {
   beforeEach: function () {
-    dataCsv = {
+    var fixture = document.getElementById('qunit-fixture')
+    var result = document.createElement('span')
+    var form = document.createElement('form')
+    var input = document.createElement('input')
+    var label = document.createElement('label')
+    var dataCsv = {
       html_settings: {
         type: 'ActionView::Helpers::FormBuilder',
         input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
@@ -9,63 +14,64 @@ QUnit.module('Element Validate Pass Callback', {
       validators: { 'user[name]': { presence: [{ message: 'must be present' }] } }
     }
 
-    $('#qunit-fixture')
-      .append($('<span id="result">'))
-      .append($('<form>', {
-        action: '/users',
-        'data-client-side-validations': JSON.stringify(dataCsv),
-        method: 'post',
-        id: 'new_user'
-      }))
-      .find('form')
-      .append($('<input />', {
-        name: 'user[name]',
-        id: 'user_name',
-        type: 'text'
-      }))
-      .append($('<label for="user_name">Name</label>'))
+    result.id = 'result'
+    form.action = '/users'
+    form.dataset.clientSideValidations = JSON.stringify(dataCsv)
+    form.method = 'post'
+    form.id = 'new_user'
+    input.name = 'user[name]'
+    input.id = 'user_name'
+    input.type = 'text'
+    label.htmlFor = 'user_name'
+    label.textContent = 'Name'
+
+    form.appendChild(input)
+    form.appendChild(label)
+    fixture.appendChild(result)
+    fixture.appendChild(form)
 
     ClientSideValidations.callbacks.element.pass = function (element) {
-      $('#result').text('Element Validate Pass ' + element.attr('id'))
+      document.getElementById('result').textContent = 'Element Validate Pass ' + element.id
     }
-    $('form#new_user').validate()
+    ClientSideValidations.validate(form)
   },
   afterEach: function () {
     ClientSideValidations.callbacks.element.pass = function (element, callback) { callback() }
+    document.getElementById('qunit-fixture').replaceChildren()
   }
 })
 
 QUnit.test('runs callback when form element validate', function (assert) {
-  var input = $('#user_name')
+  var input = document.getElementById('user_name')
 
-  assert.equal($('#result').text(), '')
+  assert.equal(document.getElementById('result').textContent, '')
 
-  input.val('')
-  input.trigger('change')
-  input.trigger('focusout')
-  assert.equal($('#result').text(), '')
+  input.value = ''
+  input.dispatchEvent(new Event('change', { bubbles: true }))
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.equal(document.getElementById('result').textContent, '')
 
-  input.val('test')
-  input.trigger('change')
-  input.trigger('focusout')
-  assert.equal($('#result').text(), 'Element Validate Pass user_name')
+  input.value = 'test'
+  input.dispatchEvent(new Event('change', { bubbles: true }))
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.equal(document.getElementById('result').textContent, 'Element Validate Pass user_name')
 })
 
 QUnit.test('runs callback when form validates', function (assert) {
-  var form = $('#new_user')
-  var input = form.find('input')
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_name')
 
-  assert.equal($('#result').text(), '')
+  assert.equal(document.getElementById('result').textContent, '')
 
-  input.val('')
-  input.trigger('change')
-  form.trigger('submit')
+  input.value = ''
+  input.dispatchEvent(new Event('change', { bubbles: true }))
+  form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
 
-  assert.equal($('#result').text(), '')
+  assert.equal(document.getElementById('result').textContent, '')
 
-  input.val('test')
-  input.trigger('change')
-  form.trigger('submit')
+  input.value = 'test'
+  input.dispatchEvent(new Event('change', { bubbles: true }))
+  form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
 
-  assert.equal($('#result').text(), 'Element Validate Pass user_name')
+  assert.equal(document.getElementById('result').textContent, 'Element Validate Pass user_name')
 })

--- a/test/javascript/public/test/callbacks/formAfter.js
+++ b/test/javascript/public/test/callbacks/formAfter.js
@@ -1,6 +1,11 @@
 QUnit.module('Form Validate After Callback', {
   beforeEach: function () {
-    dataCsv = {
+    var fixture = document.getElementById('qunit-fixture')
+    var result = document.createElement('span')
+    var form = document.createElement('form')
+    var input = document.createElement('input')
+    var label = document.createElement('label')
+    var dataCsv = {
       html_settings: {
         type: 'ActionView::Helpers::FormBuilder',
         input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
@@ -9,38 +14,38 @@ QUnit.module('Form Validate After Callback', {
       validators: { 'user[name]': { presence: [{ message: 'must be present' }] } }
     }
 
-    $('#qunit-fixture')
-      .append($('<span id="result">'))
-      .append($('<form>', {
-        action: '/users',
-        'data-client-side-validations': JSON.stringify(dataCsv),
-        method: 'post',
-        id: 'new_user'
-      }))
-      .find('form')
-      .append($('<input />', {
-        name: 'user[name]',
-        id: 'user_name',
-        type: 'text'
-      }))
-      .append($('<label for="user_name">Name</label>'))
+    result.id = 'result'
+    form.action = '/users'
+    form.dataset.clientSideValidations = JSON.stringify(dataCsv)
+    form.method = 'post'
+    form.id = 'new_user'
+    input.name = 'user[name]'
+    input.id = 'user_name'
+    input.type = 'text'
+    label.htmlFor = 'user_name'
+    label.textContent = 'Name'
 
-    ClientSideValidations.callbacks.form.after = function (form, message) {
-      $('#result').text('Form Validate After ' + form.attr('id'))
+    form.appendChild(input)
+    form.appendChild(label)
+    fixture.appendChild(result)
+    fixture.appendChild(form)
+
+    ClientSideValidations.callbacks.form.after = function (form) {
+      document.getElementById('result').textContent = 'Form Validate After ' + form.id
     }
-    $('form#new_user').validate()
+    ClientSideValidations.validate(form)
   },
   afterEach: function () {
     ClientSideValidations.callbacks.form.after = function (form, eventData) {}
+    document.getElementById('qunit-fixture').replaceChildren()
   }
 })
 
 QUnit.test('runs callback', function (assert) {
-  var form = $('#new_user')
-  var input = form.find('input')
+  var form = document.getElementById('new_user')
 
-  assert.equal($('#result').text(), '')
+  assert.equal(document.getElementById('result').textContent, '')
 
-  form.submit()
-  assert.equal($('#result').text(), 'Form Validate After new_user')
+  form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+  assert.equal(document.getElementById('result').textContent, 'Form Validate After new_user')
 })

--- a/test/javascript/public/test/callbacks/formBefore.js
+++ b/test/javascript/public/test/callbacks/formBefore.js
@@ -1,6 +1,11 @@
 QUnit.module('Form Validate Before Callback', {
   beforeEach: function () {
-    dataCsv = {
+    var fixture = document.getElementById('qunit-fixture')
+    var result = document.createElement('span')
+    var form = document.createElement('form')
+    var input = document.createElement('input')
+    var label = document.createElement('label')
+    var dataCsv = {
       html_settings: {
         type: 'ActionView::Helpers::FormBuilder',
         input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
@@ -9,38 +14,38 @@ QUnit.module('Form Validate Before Callback', {
       validators: { 'user[name]': { presence: [{ message: 'must be present' }] } }
     }
 
-    $('#qunit-fixture')
-      .append($('<span id="result">'))
-      .append($('<form>', {
-        action: '/users',
-        'data-client-side-validations': JSON.stringify(dataCsv),
-        method: 'post',
-        id: 'new_user'
-      }))
-      .find('form')
-      .append($('<input />', {
-        name: 'user[name]',
-        id: 'user_name',
-        type: 'text'
-      }))
-      .append($('<label for="user_name">Name</label>'))
+    result.id = 'result'
+    form.action = '/users'
+    form.dataset.clientSideValidations = JSON.stringify(dataCsv)
+    form.method = 'post'
+    form.id = 'new_user'
+    input.name = 'user[name]'
+    input.id = 'user_name'
+    input.type = 'text'
+    label.htmlFor = 'user_name'
+    label.textContent = 'Name'
 
-    ClientSideValidations.callbacks.form.before = function (form, message) {
-      $('#result').text('Form Validate Before ' + form.attr('id'))
+    form.appendChild(input)
+    form.appendChild(label)
+    fixture.appendChild(result)
+    fixture.appendChild(form)
+
+    ClientSideValidations.callbacks.form.before = function (form) {
+      document.getElementById('result').textContent = 'Form Validate Before ' + form.id
     }
-    $('form#new_user').validate()
+    ClientSideValidations.validate(form)
   },
   afterEach: function () {
     ClientSideValidations.callbacks.form.before = function (form, eventData) {}
+    document.getElementById('qunit-fixture').replaceChildren()
   }
 })
 
 QUnit.test('runs callback', function (assert) {
-  var form = $('#new_user')
-  var input = form.find('input')
+  var form = document.getElementById('new_user')
 
-  assert.equal($('#result').text(), '')
+  assert.equal(document.getElementById('result').textContent, '')
 
-  form.submit()
-  assert.equal($('#result').text(), 'Form Validate Before new_user')
+  form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+  assert.equal(document.getElementById('result').textContent, 'Form Validate Before new_user')
 })

--- a/test/javascript/public/test/callbacks/formFail.js
+++ b/test/javascript/public/test/callbacks/formFail.js
@@ -1,6 +1,11 @@
 QUnit.module('Form Validate Fail Callback', {
   beforeEach: function () {
-    dataCsv = {
+    var fixture = document.getElementById('qunit-fixture')
+    var result = document.createElement('span')
+    var form = document.createElement('form')
+    var input = document.createElement('input')
+    var label = document.createElement('label')
+    var dataCsv = {
       html_settings: {
         type: 'ActionView::Helpers::FormBuilder',
         input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
@@ -9,44 +14,45 @@ QUnit.module('Form Validate Fail Callback', {
       validators: { 'user[name]': { presence: [{ message: 'must be present' }] } }
     }
 
-    $('#qunit-fixture')
-      .append($('<span id="result">'))
-      .append($('<form>', {
-        action: '/users',
-        'data-client-side-validations': JSON.stringify(dataCsv),
-        method: 'post',
-        id: 'new_user'
-      }))
-      .find('form')
-      .append($('<input />', {
-        name: 'user[name]',
-        id: 'user_name',
-        type: 'text'
-      }))
-      .append($('<label for="user_name">Name</label>'))
+    result.id = 'result'
+    form.action = '/users'
+    form.dataset.clientSideValidations = JSON.stringify(dataCsv)
+    form.method = 'post'
+    form.id = 'new_user'
+    input.name = 'user[name]'
+    input.id = 'user_name'
+    input.type = 'text'
+    label.htmlFor = 'user_name'
+    label.textContent = 'Name'
 
-    ClientSideValidations.callbacks.form.fail = function (form, message) {
-      $('#result').text('Form Validate Fail ' + form.attr('id'))
+    form.appendChild(input)
+    form.appendChild(label)
+    fixture.appendChild(result)
+    fixture.appendChild(form)
+
+    ClientSideValidations.callbacks.form.fail = function (form) {
+      document.getElementById('result').textContent = 'Form Validate Fail ' + form.id
     }
-    $('form#new_user').validate()
+    ClientSideValidations.validate(form)
   },
   afterEach: function () {
     ClientSideValidations.callbacks.form.fail = function (form, eventData) {}
+    document.getElementById('qunit-fixture').replaceChildren()
   }
 })
 
 QUnit.test('runs callback', function (assert) {
-  var form = $('#new_user')
-  var input = form.find('input')
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_name')
 
-  assert.equal($('#result').text(), '')
+  assert.equal(document.getElementById('result').textContent, '')
 
-  form.submit()
-  assert.equal($('#result').text(), 'Form Validate Fail new_user')
+  form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+  assert.equal(document.getElementById('result').textContent, 'Form Validate Fail new_user')
 
-  $('#result').text('')
-  input.val('test')
-  input.trigger('change')
-  form.submit()
-  assert.equal($('#result').text(), '')
+  document.getElementById('result').textContent = ''
+  input.value = 'test'
+  input.dispatchEvent(new Event('change', { bubbles: true }))
+  form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+  assert.equal(document.getElementById('result').textContent, '')
 })

--- a/test/javascript/public/test/callbacks/formPass.js
+++ b/test/javascript/public/test/callbacks/formPass.js
@@ -1,6 +1,11 @@
 QUnit.module('Form Validate Pass Callback', {
   beforeEach: function () {
-    dataCsv = {
+    var fixture = document.getElementById('qunit-fixture')
+    var result = document.createElement('span')
+    var form = document.createElement('form')
+    var input = document.createElement('input')
+    var label = document.createElement('label')
+    var dataCsv = {
       html_settings: {
         type: 'ActionView::Helpers::FormBuilder',
         input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
@@ -9,43 +14,44 @@ QUnit.module('Form Validate Pass Callback', {
       validators: { 'user[name]': { presence: [{ message: 'must be present' }] } }
     }
 
-    $('#qunit-fixture')
-      .append($('<span id="result">'))
-      .append($('<form>', {
-        action: '/users',
-        'data-client-side-validations': JSON.stringify(dataCsv),
-        method: 'post',
-        id: 'new_user'
-      }))
-      .find('form')
-      .append($('<input />', {
-        name: 'user[name]',
-        id: 'user_name',
-        type: 'text'
-      }))
-      .append($('<label for="user_name">Name</label>'))
+    result.id = 'result'
+    form.action = '/users'
+    form.dataset.clientSideValidations = JSON.stringify(dataCsv)
+    form.method = 'post'
+    form.id = 'new_user'
+    input.name = 'user[name]'
+    input.id = 'user_name'
+    input.type = 'text'
+    label.htmlFor = 'user_name'
+    label.textContent = 'Name'
 
-    ClientSideValidations.callbacks.form.pass = function (form, message) {
-      $('#result').text('Form Validate Pass ' + form.attr('id'))
+    form.appendChild(input)
+    form.appendChild(label)
+    fixture.appendChild(result)
+    fixture.appendChild(form)
+
+    ClientSideValidations.callbacks.form.pass = function (form) {
+      document.getElementById('result').textContent = 'Form Validate Pass ' + form.id
     }
-    $('form#new_user').validate()
+    ClientSideValidations.validate(form)
   },
   afterEach: function () {
     ClientSideValidations.callbacks.form.pass = function (form, eventData) {}
+    document.getElementById('qunit-fixture').replaceChildren()
   }
 })
 
 QUnit.test('runs callback', function (assert) {
-  var form = $('#new_user')
-  var input = form.find('input')
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_name')
 
-  assert.equal($('#result').text(), '')
+  assert.equal(document.getElementById('result').textContent, '')
 
-  form.submit()
-  assert.equal($('#result').text(), '')
+  form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+  assert.equal(document.getElementById('result').textContent, '')
 
-  input.val('test')
-  input.trigger('change')
-  form.submit()
-  assert.equal($('#result').text(), 'Form Validate Pass new_user')
+  input.value = 'test'
+  input.dispatchEvent(new Event('change', { bubbles: true }))
+  form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+  assert.equal(document.getElementById('result').textContent, 'Form Validate Pass new_user')
 })

--- a/test/javascript/public/test/form_builders/validateForm.js
+++ b/test/javascript/public/test/form_builders/validateForm.js
@@ -1,5 +1,10 @@
 QUnit.module('Validate Form', {
   beforeEach: function () {
+    var fixture = document.getElementById('qunit-fixture')
+    var form = document.createElement('form')
+    var input = document.createElement('input')
+    var label = document.createElement('label')
+
     dataCsv = {
       html_settings: {
         type: 'ActionView::Helpers::FormBuilder',
@@ -9,186 +14,242 @@ QUnit.module('Validate Form', {
       validators: { 'user[name]': { presence: [{ message: 'must be present' }] } }
     }
 
-    $('#qunit-fixture')
-      .append($('<form>', {
-        action: '/users',
-        'data-client-side-validations': JSON.stringify(dataCsv),
-        method: 'post',
-        id: 'new_user'
-      }))
-      .find('form')
-      .append($('<input />', {
-        name: 'user[name]',
-        id: 'user_name',
-        type: 'text'
-      }))
-      .append($('<label for="user_name">Name</label>'))
-    $('form#new_user').validate()
+    form.action = '/users'
+    form.dataset.clientSideValidations = JSON.stringify(dataCsv)
+    form.method = 'post'
+    form.id = 'new_user'
+
+    input.name = 'user[name]'
+    input.id = 'user_name'
+    input.type = 'text'
+
+    label.htmlFor = 'user_name'
+    label.textContent = 'Name'
+
+    form.appendChild(input)
+    form.appendChild(label)
+    fixture.appendChild(form)
+
+    ClientSideValidations.validate(form)
   }
 })
 
 QUnit.test('Validate form with invalid form (async)', function (assert) {
   var done = assert.async()
-  var form = $('form#new_user')
-  var input = form.find('input#user_name')
-  var label = $('label[for="user_name"]')
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_name')
+  var label = form.querySelector('label[for="user_name"]')
 
-  form.trigger('submit')
+  form.requestSubmit()
 
   setTimeout(function () {
-    assert.ok(input.parent().hasClass('field_with_errors'))
-    assert.ok(label.parent().hasClass('field_with_errors'))
-    assert.ok(input.parent().find('label:contains("must be present")')[0])
-    assert.notOk($('iframe').contents().find('p:contains("Form submitted")')[0])
+    var iframe = document.querySelector('iframe')
+    var response = iframe && iframe.contentDocument && iframe.contentDocument.querySelector('#response')
+
+    assert.ok(input.parentElement.classList.contains('field_with_errors'))
+    assert.ok(label.parentElement.classList.contains('field_with_errors'))
+    assert.ok(input.parentElement.querySelector('label.message'))
+    assert.notOk(response)
     done()
   }, 250)
 })
 
 QUnit.test('Validate form with valid form (async)', function (assert) {
   var done = assert.async()
-  var form = $('form#new_user')
-  var input = form.find('input#user_name')
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_name')
 
-  input.val('Test')
-
-  form.trigger('submit')
+  input.value = 'Test'
+  form.requestSubmit()
 
   setTimeout(function () {
-    assert.ok($('iframe').contents().find('p:contains("Form submitted")')[0])
+    var iframe = document.querySelector('iframe')
+    var response = iframe && iframe.contentDocument && iframe.contentDocument.querySelector('#response')
+
+    assert.ok(response)
     done()
   }, 250)
 })
 
 QUnit.test('Validate form with an input changed to false (async)', function (assert) {
   var done = assert.async()
-  var form = $('form#new_user')
-  var input = form.find('input#user_name')
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_name')
 
-  input.val('Test')
-  input[0].dataset.csvChanged = 'false'
+  input.value = 'Test'
+  input.dataset.csvChanged = 'false'
 
-  form.trigger('submit')
+  form.requestSubmit()
 
   setTimeout(function () {
-    assert.ok($('iframe').contents().find('p:contains("Form submitted")')[0])
+    var iframe = document.querySelector('iframe')
+    var response = iframe && iframe.contentDocument && iframe.contentDocument.querySelector('#response')
+
+    assert.ok(response)
     done()
   }, 250)
 })
 
 QUnit.test('Ensure ajax:beforeSend is not from a bubbled event (async)', function (assert) {
   var done = assert.async()
-  var form = $('form#new_user')
-  var input = form.find('input#user_name')
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_name')
+  var link = document.createElement('a')
 
-  form
-    .append('<a>')
-    .find('a').trigger('ajax:beforeSend')
+  form.appendChild(link)
+  link.dispatchEvent(new CustomEvent('ajax:beforeSend', { bubbles: true }))
 
   setTimeout(function () {
-    assert.notOk(input.parent().hasClass('field_with_errors'))
+    assert.notOk(input.parentElement.classList.contains('field_with_errors'))
     done()
   }, 250)
 })
 
 QUnit.test('Validate form with invalid form and disabling validations (async)', function (assert) {
   var done = assert.async()
-  var form = $('form#new_user')
-  var input = form.find('input#user_name')
-  var label = $('label[for="user_name"]')
+  var form = document.getElementById('new_user')
 
-  form.disableClientSideValidations()
-  form.trigger('submit')
+  ClientSideValidations.disable(form)
+  form.requestSubmit()
 
   setTimeout(function () {
-    assert.ok($('iframe').contents().find('p:contains("Form submitted")')[0])
+    var iframe = document.querySelector('iframe')
+    var response = iframe && iframe.contentDocument && iframe.contentDocument.querySelector('#response')
+
+    assert.ok(response)
     done()
   }, 250)
 })
 
 QUnit.test('Handle disable-with (async)', function (assert) {
   var done = assert.async()
-  var form = $('form#new_user')
-  var input = form.find('input#user_name')
-  var label = $('label[for="user_name"]')
+  var form = document.getElementById('new_user')
+  var submitButton = document.createElement('input')
 
-  form.append($('<input />', {
-    type: 'submit',
-    'data-disable-with': 'Waiting...',
-    name: 'commit',
-    value: 'Save',
-    id: 'submit_button'
-  }))
+  submitButton.type = 'submit'
+  submitButton.dataset.disableWith = 'Waiting...'
+  submitButton.name = 'commit'
+  submitButton.value = 'Save'
+  submitButton.id = 'submit_button'
+  form.appendChild(submitButton)
 
-  form.trigger('submit')
+  form.requestSubmit(submitButton)
 
   setTimeout(function () {
-    assert.ok($('#submit_button').attr('disabled') === undefined)
+    assert.notOk(submitButton.disabled)
     done()
   }, 250)
 })
 
 QUnit.test('Disabled inputs do not stop form submission (async)', function (assert) {
   var done = assert.async()
-  var form = $('form#new_user')
-  var input = form.find('input#user_name')
-  var label = $('label[for="user_name"]')
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_name')
 
-  input.disableClientSideValidations()
-  form.trigger('submit')
+  ClientSideValidations.disable(input)
+  form.requestSubmit()
 
   setTimeout(function () {
-    assert.ok($('iframe').contents().find('p:contains("Form submitted")')[0])
+    var iframe = document.querySelector('iframe')
+    var response = iframe && iframe.contentDocument && iframe.contentDocument.querySelector('#response')
+
+    assert.ok(response)
+    done()
+  }, 250)
+})
+
+QUnit.test('Inputs inside hidden containers do not stop form submission (async)', function (assert) {
+  var done = assert.async()
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_name')
+  var label = form.querySelector('label[for="user_name"]')
+  var hiddenContainer = document.createElement('div')
+
+  hiddenContainer.hidden = true
+  form.insertBefore(hiddenContainer, input)
+  hiddenContainer.appendChild(input)
+  hiddenContainer.appendChild(label)
+
+  form.requestSubmit()
+
+  setTimeout(function () {
+    var iframe = document.querySelector('iframe')
+    var response = iframe && iframe.contentDocument && iframe.contentDocument.querySelector('#response')
+
+    assert.ok(response)
+    assert.notOk(input.parentElement.classList.contains('field_with_errors'))
     done()
   }, 250)
 })
 
 QUnit.test('Decorative (without name) inputs aren\'t validated (async)', function (assert) {
   var done = assert.async()
-  var form = $('form#new_user')
-  var input = form.find('input#user_name')
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_name')
+  var decorativeInput = document.createElement('input')
 
-  input.val('Test')
-  form.append($('<input />', { type: 'text' })).validate()
+  input.value = 'Test'
+  decorativeInput.type = 'text'
+  form.appendChild(decorativeInput)
+  ClientSideValidations.validate(form)
 
-  form.trigger('submit')
+  form.requestSubmit()
 
   setTimeout(function () {
-    assert.ok($('iframe').contents().find('p:contains("Form submitted")')[0])
+    var iframe = document.querySelector('iframe')
+    var response = iframe && iframe.contentDocument && iframe.contentDocument.querySelector('#response')
+
+    assert.ok(response)
     done()
   }, 250)
 })
 
 QUnit.test('Resetting client side validations', function (assert) {
-  var form = $('form#new_user')
-  var input = form.find('input#user_name')
-  var label = $('label[for="user_name"]')
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_name')
+  var label = form.querySelector('label[for="user_name"]')
 
-  form.trigger('submit')
-  assert.ok(input.parent().hasClass('field_with_errors'))
-  assert.ok(label.parent().hasClass('field_with_errors'))
-  assert.ok(input.parent().find('label:contains("must be present")')[0])
+  form.requestSubmit()
+  assert.ok(input.parentElement.classList.contains('field_with_errors'))
+  assert.ok(label.parentElement.classList.contains('field_with_errors'))
+  assert.ok(input.parentElement.querySelector('label.message'))
 
-  form.resetClientSideValidations()
-  assert.notOk(input.parent().hasClass('field_with_errors'))
-  assert.notOk(label.parent().hasClass('field_with_errors'))
-  assert.notOk(input.parent().find('label:contains("must be present")')[0])
+  ClientSideValidations.reset(form)
+  assert.notOk(input.parentElement.classList.contains('field_with_errors'))
+  assert.notOk(label.parentElement.classList.contains('field_with_errors'))
+  assert.notOk(input.parentElement.querySelector('label.message'))
 
-  form.trigger('submit')
-  assert.ok(input.parent().hasClass('field_with_errors'))
-  assert.ok(label.parent().hasClass('field_with_errors'))
-  assert.ok(input.parent().find('label:contains("must be present")')[0])
+  form.requestSubmit()
+  assert.ok(input.parentElement.classList.contains('field_with_errors'))
+  assert.ok(label.parentElement.classList.contains('field_with_errors'))
+  assert.ok(input.parentElement.querySelector('label.message'))
 })
 
 QUnit.test('Disable client side validations on all child inputs', function (assert) {
-  var form = $('form#new_user')
-  var input = form.find('input#user_name')
-  var label = $('label[for="user_name"]')
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_name')
+  var label = form.querySelector('label[for="user_name"]')
 
-  form.disableClientSideValidations()
+  ClientSideValidations.disable(form)
 
-  input.trigger('focusout')
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
 
-  assert.notOk(input.parent().hasClass('field_with_errors'))
-  assert.notOk(label.parent().hasClass('field_with_errors'))
-  assert.notOk(input.parent().find('label:contains("must be present")')[0])
+  assert.notOk(input.parentElement.classList.contains('field_with_errors'))
+  assert.notOk(label.parentElement.classList.contains('field_with_errors'))
+  assert.notOk(input.parentElement.querySelector('label.message'))
+})
+
+QUnit.test('Disable ignores non-element nodes in mixed collections', function (assert) {
+  var input = document.getElementById('user_name')
+  var textNode = document.createTextNode('ignored node')
+
+  assert.ok(input.dataset.csvValidate)
+
+  ClientSideValidations.disable([document, textNode, input])
+
+  assert.strictEqual(input.dataset.csvValidate, undefined)
+
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+
+  assert.notOk(input.parentElement.classList.contains('field_with_errors'))
 })

--- a/test/javascript/public/test/settings.js
+++ b/test/javascript/public/test/settings.js
@@ -1,25 +1,24 @@
 QUnit.config.autostart = window.location.search.search('autostart=false') < 0
 
-QUnit.config.urlConfig.push({
-  id: 'jquery',
-  label: 'jQuery version',
-  value: ['3.7.1', '3.7.1.slim'],
-  tooltip: 'What jQuery Core version to test against'
-})
+var iframeSequence = 0
 
 /* Hijacks normal form submit; lets it submit to an iframe to prevent
  * navigating away from the test suite
  */
-$(document).on('submit', function (e) {
-  if (!e.isDefaultPrevented()) {
-    var form = $(e.target)
-    var action = form.attr('action')
-    var name = 'form-frame' + jQuery.guid++
-    var iframe = $('<iframe>', { name: name })
-
-    if (action && action.indexOf('iframe') < 0) form.attr('action', action + '?iframe=true')
-    form.attr('target', name)
-    $('#qunit-fixture').append(iframe)
-    form.trigger('iframe:loading')
+document.addEventListener('submit', function (event) {
+  if (event.defaultPrevented || !(event.target instanceof HTMLFormElement)) {
+    return
   }
+
+  var form = event.target
+  var action = form.getAttribute('action')
+  var name = 'form-frame' + iframeSequence++
+  var iframe = document.createElement('iframe')
+
+  iframe.name = name
+
+  if (action && action.indexOf('iframe') < 0) form.setAttribute('action', action + '?iframe=true')
+  form.setAttribute('target', name)
+  document.getElementById('qunit-fixture').appendChild(iframe)
+  form.dispatchEvent(new CustomEvent('iframe:loading', { bubbles: true }))
 })

--- a/test/javascript/public/test/validateElement.js
+++ b/test/javascript/public/test/validateElement.js
@@ -1,5 +1,40 @@
 QUnit.module('Validate Element', {
   beforeEach: function () {
+    var fixture = document.getElementById('qunit-fixture')
+    var form = document.createElement('form')
+    var labelUserName = document.createElement('label')
+    var inputUserName = document.createElement('input')
+    var labelPassword = document.createElement('label')
+    var inputPassword = document.createElement('input')
+    var labelPasswordConfirmation = document.createElement('label')
+    var inputPasswordConfirmation = document.createElement('input')
+    var labelAgree = document.createElement('label')
+    var inputAgree = document.createElement('input')
+    var inputEmail = document.createElement('input')
+    var labelPhone0 = document.createElement('label')
+    var inputPhone0 = document.createElement('input')
+    var inputPhone0Destroy = document.createElement('input')
+    var labelPhone1 = document.createElement('label')
+    var inputPhone1 = document.createElement('input')
+    var labelPhone2 = document.createElement('label')
+    var inputPhone2 = document.createElement('input')
+    var labelPhoneNew = document.createElement('label')
+    var inputPhoneNew = document.createElement('input')
+    var labelCountryCode = document.createElement('label')
+    var inputCountryCode = document.createElement('input')
+    var labelDeepNested0 = document.createElement('label')
+    var inputDeepNested0 = document.createElement('input')
+    var labelDeepNestedObjectId = document.createElement('label')
+    var inputDeepNestedObjectId = document.createElement('input')
+    var labelLabelsNested = document.createElement('label')
+    var inputLabelsNested = document.createElement('input')
+    var labelDeepAttributes = document.createElement('label')
+    var inputDeepAttributes = document.createElement('input')
+    var labelEyeColor = document.createElement('label')
+    var inputEyeColor = document.createElement('input')
+    var labelCustomizedField = document.createElement('label')
+    var inputCustomizedField = document.createElement('input')
+
     dataCsv = {
       html_settings: {
         type: 'ActionView::Helpers::FormBuilder',
@@ -22,342 +57,395 @@ QUnit.module('Validate Element', {
       }
     }
 
-    $('#qunit-fixture')
-      .append($('<form>', {
-        action: '/users',
-        'data-client-side-validations': JSON.stringify(dataCsv),
-        method: 'post',
-        id: 'new_user'
-      }))
-      .find('form')
-      .append($('<label for="user_name">Name</label>'))
-      .append($('<input />', {
-        name: 'user[name]',
-        id: 'user_name',
-        type: 'text'
-      }))
-      .append($('<label for="user_password">Password</label>'))
-      .append($('<input />', {
-        name: 'user[password]',
-        id: 'user_password',
-        type: 'password'
-      }))
-      .append($('<label for="user_password_confirmation">Password Confirmation</label>'))
-      .append($('<input />', {
-        name: 'user[password_confirmation]',
-        id: 'user_password_confirmation',
-        type: 'password'
-      }))
-      .append($('<label for="user_agree">Agree</label>'))
-      .append($('<input />', {
-        name: 'user[agree]',
-        id: 'user_agree',
-        type: 'checkbox',
-        value: 1
-      }))
-      .append($('<input />', {
-        name: 'user[email]',
-        id: 'user_email',
-        type: 'text'
-      }))
-      .append($('<label for="user_phone_numbers_attributes_0_number">Phone Number</label>'))
-      .append($('<input />', {
-        name: 'user[phone_numbers_attributes][0][number]',
-        id: 'user_phone_numbers_attributes_0_number',
-        type: 'text'
-      }))
-      .append($('<input />', {
-        name: 'user[phone_numbers_attributes][0][_destroy]',
-        id: 'user_phone_numbers_attributes_0__destroy',
-        type: 'hidden',
-        value: '1'
-      }))
-      .append($('<label for="user_phone_numbers_attributes_1_number">Phone Number</label>'))
-      .append($('<input />', {
-        name: 'user[phone_numbers_attributes][1][number]',
-        id: 'user_phone_numbers_attributes_1_number',
-        type: 'text'
-      }))
-      .append($('<label for="user_phone_numbers_attributes_2_number">Phone Number</label>'))
-      .append($('<input />', {
-        name: 'user[phone_numbers_attributes][2][number]',
-        id: 'user_phone_numbers_attributes_2_number',
-        type: 'text'
-      }))
-      .append($('<label for="user_phone_numbers_attributes_new_1234_number">Phone Number</label>'))
-      .append($('<input />', {
-        name: 'user[phone_numbers_attributes][new_1234][number]',
-        id: 'user_phone_numbers_attributes_new_1234_number',
-        type: 'text'
-      }))
-      .append($('<label for="user_phone_numbers_attributes_country_code_0_code">Country code</label>'))
-      .append($('<input />', {
-        name: 'user[phone_numbers_attributes][country_code][0][code]',
-        id: 'user_phone_numbers_attributes_country_code_0_code',
-        type: 'text'
-      }))
-      .append($('<label for="user_phone_numbers_attributes_deeply_nested_0_attribute">Deeply nested attribute</label>'))
-      .append($('<input />', {
-        name: 'user[phone_numbers_attributes][deeply][nested][0][attribute]',
-        id: 'user_phone_numbers_attributes_deeply_nested_0_attribute',
-        type: 'text'
-      }))
-      .append($('<label for="user_phone_numbers_attributes_deeply_nested_5154ce728c06dedad4000001_attribute">Deeply nested attribute</label>'))
-      .append($('<input />', {
-        name: 'user[phone_numbers_attributes][deeply][nested][5154ce728c06dedad4000001][attribute]',
-        id: 'user_phone_numbers_attributes_deeply_nested_5154ce728c06dedad4000001_attribute',
-        type: 'text'
-      }))
-      .append($('<label for="user_phone_numbers_attributes_1_labels_attributes_2_label">Two rails-nested-attributes</label>'))
-      .append($('<input />', {
-        name: 'user[phone_numbers_attributes][1][labels_attributes][2][label]',
-        id: 'user_phone_numbers_attributes_1_labels_attributes_2_label',
-        type: 'text'
-      }))
-      .append($('<label for="user_a_attributes_1_b_attributes_2_c_attributes_3_d_attributes_4_e">Two rails-nested-attributes</label>'))
-      .append($('<input />', {
-        name: 'user[a_attributes][1][b_attributes][2][c_attributes][3][d_attributes][4][e]',
-        id: 'user_a_attributes_1_b_attributes_2_c_attributes_3_d_attributes_4_e',
-        type: 'text'
-      }))
-      .append($('<label for="user_info_attributes_eye_color">Eye Color</label>'))
-      .append($('<input />', {
-        name: 'user[info_attributes][eye_color]',
-        id: 'user_info_attributes_eye_color',
-        type: 'text'
-      }))
-      .append($('<label for="customized_field">Customized Field</label>'))
-      .append($('<input />', {
-        name: 'customized_field',
-        id: 'customized_field',
-        type: 'text'
-      }))
+    form.action = '/users'
+    form.dataset.clientSideValidations = JSON.stringify(dataCsv)
+    form.method = 'post'
+    form.id = 'new_user'
 
-    $('form#new_user').validate()
+    labelUserName.htmlFor = 'user_name'
+    labelUserName.textContent = 'Name'
+    form.appendChild(labelUserName)
+
+    inputUserName.name = 'user[name]'
+    inputUserName.id = 'user_name'
+    inputUserName.type = 'text'
+    form.appendChild(inputUserName)
+
+    labelPassword.htmlFor = 'user_password'
+    labelPassword.textContent = 'Password'
+    form.appendChild(labelPassword)
+
+    inputPassword.name = 'user[password]'
+    inputPassword.id = 'user_password'
+    inputPassword.type = 'password'
+    form.appendChild(inputPassword)
+
+    labelPasswordConfirmation.htmlFor = 'user_password_confirmation'
+    labelPasswordConfirmation.textContent = 'Password Confirmation'
+    form.appendChild(labelPasswordConfirmation)
+
+    inputPasswordConfirmation.name = 'user[password_confirmation]'
+    inputPasswordConfirmation.id = 'user_password_confirmation'
+    inputPasswordConfirmation.type = 'password'
+    form.appendChild(inputPasswordConfirmation)
+
+    labelAgree.htmlFor = 'user_agree'
+    labelAgree.textContent = 'Agree'
+    form.appendChild(labelAgree)
+
+    inputAgree.name = 'user[agree]'
+    inputAgree.id = 'user_agree'
+    inputAgree.type = 'checkbox'
+    inputAgree.value = '1'
+    form.appendChild(inputAgree)
+
+    inputEmail.name = 'user[email]'
+    inputEmail.id = 'user_email'
+    inputEmail.type = 'text'
+    form.appendChild(inputEmail)
+
+    labelPhone0.htmlFor = 'user_phone_numbers_attributes_0_number'
+    labelPhone0.textContent = 'Phone Number'
+    form.appendChild(labelPhone0)
+
+    inputPhone0.name = 'user[phone_numbers_attributes][0][number]'
+    inputPhone0.id = 'user_phone_numbers_attributes_0_number'
+    inputPhone0.type = 'text'
+    form.appendChild(inputPhone0)
+
+    inputPhone0Destroy.name = 'user[phone_numbers_attributes][0][_destroy]'
+    inputPhone0Destroy.id = 'user_phone_numbers_attributes_0__destroy'
+    inputPhone0Destroy.type = 'hidden'
+    inputPhone0Destroy.value = '1'
+    form.appendChild(inputPhone0Destroy)
+
+    labelPhone1.htmlFor = 'user_phone_numbers_attributes_1_number'
+    labelPhone1.textContent = 'Phone Number'
+    form.appendChild(labelPhone1)
+
+    inputPhone1.name = 'user[phone_numbers_attributes][1][number]'
+    inputPhone1.id = 'user_phone_numbers_attributes_1_number'
+    inputPhone1.type = 'text'
+    form.appendChild(inputPhone1)
+
+    labelPhone2.htmlFor = 'user_phone_numbers_attributes_2_number'
+    labelPhone2.textContent = 'Phone Number'
+    form.appendChild(labelPhone2)
+
+    inputPhone2.name = 'user[phone_numbers_attributes][2][number]'
+    inputPhone2.id = 'user_phone_numbers_attributes_2_number'
+    inputPhone2.type = 'text'
+    form.appendChild(inputPhone2)
+
+    labelPhoneNew.htmlFor = 'user_phone_numbers_attributes_new_1234_number'
+    labelPhoneNew.textContent = 'Phone Number'
+    form.appendChild(labelPhoneNew)
+
+    inputPhoneNew.name = 'user[phone_numbers_attributes][new_1234][number]'
+    inputPhoneNew.id = 'user_phone_numbers_attributes_new_1234_number'
+    inputPhoneNew.type = 'text'
+    form.appendChild(inputPhoneNew)
+
+    labelCountryCode.htmlFor = 'user_phone_numbers_attributes_country_code_0_code'
+    labelCountryCode.textContent = 'Country code'
+    form.appendChild(labelCountryCode)
+
+    inputCountryCode.name = 'user[phone_numbers_attributes][country_code][0][code]'
+    inputCountryCode.id = 'user_phone_numbers_attributes_country_code_0_code'
+    inputCountryCode.type = 'text'
+    form.appendChild(inputCountryCode)
+
+    labelDeepNested0.htmlFor = 'user_phone_numbers_attributes_deeply_nested_0_attribute'
+    labelDeepNested0.textContent = 'Deeply nested attribute'
+    form.appendChild(labelDeepNested0)
+
+    inputDeepNested0.name = 'user[phone_numbers_attributes][deeply][nested][0][attribute]'
+    inputDeepNested0.id = 'user_phone_numbers_attributes_deeply_nested_0_attribute'
+    inputDeepNested0.type = 'text'
+    form.appendChild(inputDeepNested0)
+
+    labelDeepNestedObjectId.htmlFor = 'user_phone_numbers_attributes_deeply_nested_5154ce728c06dedad4000001_attribute'
+    labelDeepNestedObjectId.textContent = 'Deeply nested attribute'
+    form.appendChild(labelDeepNestedObjectId)
+
+    inputDeepNestedObjectId.name = 'user[phone_numbers_attributes][deeply][nested][5154ce728c06dedad4000001][attribute]'
+    inputDeepNestedObjectId.id = 'user_phone_numbers_attributes_deeply_nested_5154ce728c06dedad4000001_attribute'
+    inputDeepNestedObjectId.type = 'text'
+    form.appendChild(inputDeepNestedObjectId)
+
+    labelLabelsNested.htmlFor = 'user_phone_numbers_attributes_1_labels_attributes_2_label'
+    labelLabelsNested.textContent = 'Two rails-nested-attributes'
+    form.appendChild(labelLabelsNested)
+
+    inputLabelsNested.name = 'user[phone_numbers_attributes][1][labels_attributes][2][label]'
+    inputLabelsNested.id = 'user_phone_numbers_attributes_1_labels_attributes_2_label'
+    inputLabelsNested.type = 'text'
+    form.appendChild(inputLabelsNested)
+
+    labelDeepAttributes.htmlFor = 'user_a_attributes_1_b_attributes_2_c_attributes_3_d_attributes_4_e'
+    labelDeepAttributes.textContent = 'Two rails-nested-attributes'
+    form.appendChild(labelDeepAttributes)
+
+    inputDeepAttributes.name = 'user[a_attributes][1][b_attributes][2][c_attributes][3][d_attributes][4][e]'
+    inputDeepAttributes.id = 'user_a_attributes_1_b_attributes_2_c_attributes_3_d_attributes_4_e'
+    inputDeepAttributes.type = 'text'
+    form.appendChild(inputDeepAttributes)
+
+    labelEyeColor.htmlFor = 'user_info_attributes_eye_color'
+    labelEyeColor.textContent = 'Eye Color'
+    form.appendChild(labelEyeColor)
+
+    inputEyeColor.name = 'user[info_attributes][eye_color]'
+    inputEyeColor.id = 'user_info_attributes_eye_color'
+    inputEyeColor.type = 'text'
+    form.appendChild(inputEyeColor)
+
+    labelCustomizedField.htmlFor = 'customized_field'
+    labelCustomizedField.textContent = 'Customized Field'
+    form.appendChild(labelCustomizedField)
+
+    inputCustomizedField.name = 'customized_field'
+    inputCustomizedField.id = 'customized_field'
+    inputCustomizedField.type = 'text'
+    form.appendChild(inputCustomizedField)
+
+    fixture.appendChild(form)
+
+    ClientSideValidations.validate(form)
   },
 
   afterEach: function () {
-    $('#qunit-fixture').remove('form')
+    document.getElementById('qunit-fixture').replaceChildren()
   }
 })
 
 QUnit.test('Validate when focusouting on customized_field', function (assert) {
-  var form = $('form#new_user')
-  var input = form.find('input#customized_field')
-  var label = $('label[for="customized_field"]')
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('customized_field')
+  var label = form.querySelector('label[for="customized_field"]')
 
-  input.val('1')
-  input.trigger('focusout')
-  assert.ok(input.parent().hasClass('field_with_errors'))
-  assert.ok(label.parent().hasClass('field_with_errors'))
+  input.value = '1'
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.ok(input.parentElement.classList.contains('field_with_errors'))
+  assert.ok(label.parentElement.classList.contains('field_with_errors'))
 })
 
 QUnit.test('Validate when focusouting', function (assert) {
-  var form = $('form#new_user')
-  var input = form.find('input#user_name')
-  var label = $('label[for="user_name"]')
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_name')
+  var label = form.querySelector('label[for="user_name"]')
 
-  input.trigger('focusout')
-  assert.ok(input.parent().hasClass('field_with_errors'))
-  assert.ok(label.parent().hasClass('field_with_errors'))
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.ok(input.parentElement.classList.contains('field_with_errors'))
+  assert.ok(label.parentElement.classList.contains('field_with_errors'))
 })
 
 QUnit.test('Validate when checkbox is clicked', function (assert) {
-  var form = $('form#new_user')
-  var input = form.find('input#user_agree')
-  var label = $('label[for="user_agree"]')
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_agree')
+  var label = form.querySelector('label[for="user_agree"]')
 
-  input.prop('checked', true)
-  input.trigger('click')
-  assert.ok(input.parent().hasClass('field_with_errors'))
-  assert.ok(label.parent().hasClass('field_with_errors'))
+  input.checked = true
+  input.click()
+  assert.ok(input.parentElement.classList.contains('field_with_errors'))
+  assert.ok(label.parentElement.classList.contains('field_with_errors'))
 })
 
 QUnit.test('Validate when focusout on confirmation', function (assert) {
-  var form = $('form#new_user')
-  var password = form.find('input#user_password')
-  var confirmation = form.find('input#user_password_confirmation')
-  var label = $('label[for="user_password"]')
+  var form = document.getElementById('new_user')
+  var password = document.getElementById('user_password')
+  var confirmation = document.getElementById('user_password_confirmation')
+  var label = form.querySelector('label[for="user_password"]')
 
-  password.val('password')
-  confirmation.trigger('focusout')
-  assert.ok(password.parent().hasClass('field_with_errors'))
-  assert.ok(label.parent().hasClass('field_with_errors'))
+  password.value = 'password'
+  confirmation.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.ok(password.parentElement.classList.contains('field_with_errors'))
+  assert.ok(label.parentElement.classList.contains('field_with_errors'))
 })
 
 QUnit.test('Validate nested attributes', function (assert) {
-  var form = $('form#new_user')
-  var input = form.find('input#user_phone_numbers_attributes_1_number')
-  var label = $('label[for="user_phone_numbers_attributes_1_number"]')
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_phone_numbers_attributes_1_number')
+  var label = form.querySelector('label[for="user_phone_numbers_attributes_1_number"]')
 
-  input.trigger('focusout')
-  assert.ok(input.parent().hasClass('field_with_errors'))
-  assert.ok(label.parent().hasClass('field_with_errors'))
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.ok(input.parentElement.classList.contains('field_with_errors'))
+  assert.ok(label.parentElement.classList.contains('field_with_errors'))
 
-  input = form.find('input#user_phone_numbers_attributes_0_number')
-  label = $('label[for="user_phone_numbers_attributes_0_number"]')
-  input.trigger('focusout')
-  assert.notOk(input.parent().hasClass('field_with_errors'))
-  assert.notOk(label.parent().hasClass('field_with_errors'))
+  input = document.getElementById('user_phone_numbers_attributes_0_number')
+  label = form.querySelector('label[for="user_phone_numbers_attributes_0_number"]')
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.notOk(input.parentElement.classList.contains('field_with_errors'))
+  assert.notOk(label.parentElement.classList.contains('field_with_errors'))
 
-  input = form.find('input#user_phone_numbers_attributes_new_1234_number')
-  label = $('label[for="user_phone_numbers_attributes_new_1234_number"]')
-  input.trigger('focusout')
-  assert.ok(input.parent().hasClass('field_with_errors'))
-  assert.ok(label.parent().hasClass('field_with_errors'))
+  input = document.getElementById('user_phone_numbers_attributes_new_1234_number')
+  label = form.querySelector('label[for="user_phone_numbers_attributes_new_1234_number"]')
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.ok(input.parentElement.classList.contains('field_with_errors'))
+  assert.ok(label.parentElement.classList.contains('field_with_errors'))
 
-  input = form.find('input#user_phone_numbers_attributes_country_code_0_code')
-  label = $('label[for="user_phone_numbers_attributes_country_code_0_code"]')
-  input.trigger('focusout')
-  assert.ok(input.parent().hasClass('field_with_errors'))
-  assert.ok(label.parent().hasClass('field_with_errors'))
+  input = document.getElementById('user_phone_numbers_attributes_country_code_0_code')
+  label = form.querySelector('label[for="user_phone_numbers_attributes_country_code_0_code"]')
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.ok(input.parentElement.classList.contains('field_with_errors'))
+  assert.ok(label.parentElement.classList.contains('field_with_errors'))
 
-  input = form.find('input#user_phone_numbers_attributes_deeply_nested_0_attribute')
-  label = $('label[for="user_phone_numbers_attributes_deeply_nested_0_attribute"]')
-  input.trigger('focusout')
-  assert.ok(input.parent().hasClass('field_with_errors'))
-  assert.ok(label.parent().hasClass('field_with_errors'))
+  input = document.getElementById('user_phone_numbers_attributes_deeply_nested_0_attribute')
+  label = form.querySelector('label[for="user_phone_numbers_attributes_deeply_nested_0_attribute"]')
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.ok(input.parentElement.classList.contains('field_with_errors'))
+  assert.ok(label.parentElement.classList.contains('field_with_errors'))
 
-  input = form.find('input#user_phone_numbers_attributes_deeply_nested_5154ce728c06dedad4000001_attribute')
-  label = $('label[for="user_phone_numbers_attributes_deeply_nested_5154ce728c06dedad4000001_attribute"]')
-  input.trigger('focusout')
-  assert.ok(input.parent().hasClass('field_with_errors'))
-  assert.ok(label.parent().hasClass('field_with_errors'))
+  input = document.getElementById('user_phone_numbers_attributes_deeply_nested_5154ce728c06dedad4000001_attribute')
+  label = form.querySelector('label[for="user_phone_numbers_attributes_deeply_nested_5154ce728c06dedad4000001_attribute"]')
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.ok(input.parentElement.classList.contains('field_with_errors'))
+  assert.ok(label.parentElement.classList.contains('field_with_errors'))
 
-  input = form.find('input#user_phone_numbers_attributes_1_labels_attributes_2_label')
-  label = $('label[for="user_phone_numbers_attributes_1_labels_attributes_2_label"]')
-  input.trigger('focusout')
-  assert.ok(input.parent().hasClass('field_with_errors'))
-  assert.ok(label.parent().hasClass('field_with_errors'))
+  input = document.getElementById('user_phone_numbers_attributes_1_labels_attributes_2_label')
+  label = form.querySelector('label[for="user_phone_numbers_attributes_1_labels_attributes_2_label"]')
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.ok(input.parentElement.classList.contains('field_with_errors'))
+  assert.ok(label.parentElement.classList.contains('field_with_errors'))
 
-  input = form.find('input#user_a_attributes_1_b_attributes_2_c_attributes_3_d_attributes_4_e')
-  label = $('label[for="user_a_attributes_1_b_attributes_2_c_attributes_3_d_attributes_4_e"]')
-  input.trigger('focusout')
-  assert.ok(input.parent().hasClass('field_with_errors'))
-  assert.ok(label.parent().hasClass('field_with_errors'))
+  input = document.getElementById('user_a_attributes_1_b_attributes_2_c_attributes_3_d_attributes_4_e')
+  label = form.querySelector('label[for="user_a_attributes_1_b_attributes_2_c_attributes_3_d_attributes_4_e"]')
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.ok(input.parentElement.classList.contains('field_with_errors'))
+  assert.ok(label.parentElement.classList.contains('field_with_errors'))
 })
 
 QUnit.test('Validate nested attributes with custom validation', function (assert) {
-  var form = $('form#new_user')
-  var input = form.find('input#user_phone_numbers_attributes_2_number')
-  var label = $('label[for="user_phone_numbers_attributes_2_number"]')
+  var input = document.getElementById('user_phone_numbers_attributes_2_number')
 
-  input.val('1')
-  input.trigger('focusout')
-  assert.equal(input.parent().find('label').text(), 'is too short (minimum is 4 characters)')
+  input.value = '1'
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.equal(input.parentElement.querySelector('label.message').textContent, 'is too short (minimum is 4 characters)')
 })
 
 QUnit.test('Validate additional attributes', function (assert) {
-  var form = $('form#new_user')
-  var input = form.find('input#user_info_attributes_eye_color')
-  var label = $('label[for="user_info_attributes_eye_color"]')
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_info_attributes_eye_color')
+  var label = form.querySelector('label[for="user_info_attributes_eye_color"]')
 
-  input.trigger('focusout')
-  assert.ok(input.parent().hasClass('field_with_errors'))
-  assert.ok(label.parent().hasClass('field_with_errors'))
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.ok(input.parentElement.classList.contains('field_with_errors'))
+  assert.ok(label.parentElement.classList.contains('field_with_errors'))
 })
 
 QUnit.test('Validate when keyup on confirmation', function (assert) {
-  var form = $('form#new_user')
-  var password = form.find('input#user_password')
-  var confirmation = form.find('input#user_password_confirmation')
-  var label = $('label[for="user_password"]')
+  var form = document.getElementById('new_user')
+  var password = document.getElementById('user_password')
+  var confirmation = document.getElementById('user_password_confirmation')
+  var label = form.querySelector('label[for="user_password"]')
 
-  password.val('password')
+  password.value = 'password'
 
-  confirmation.trigger('keyup')
-  assert.ok(password.parent().hasClass('field_with_errors'))
-  assert.ok(label.parent().hasClass('field_with_errors'))
+  confirmation.dispatchEvent(new Event('keyup', { bubbles: true }))
+  assert.ok(password.parentElement.classList.contains('field_with_errors'))
+  assert.ok(label.parentElement.classList.contains('field_with_errors'))
 
-  confirmation.val('password')
-  confirmation.trigger('keyup')
-  assert.notOk(password.parent().hasClass('field_with_errors'))
-  assert.notOk(label.parent().hasClass('field_with_errors'))
+  confirmation.value = 'password'
+  confirmation.dispatchEvent(new Event('keyup', { bubbles: true }))
+  assert.notOk(password.parentElement.classList.contains('field_with_errors'))
+  assert.notOk(label.parentElement.classList.contains('field_with_errors'))
 })
 
 QUnit.test('Forcing remote validators to run last', function (assert) {
-  var form = $('form#new_user')
-  var input = form.find('input#user_email')
+  var input = document.getElementById('user_email')
 
-  input.trigger('focusout')
-  assert.equal(input.parent().find('label').text(), 'must be present')
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.equal(input.parentElement.querySelector('label.message').textContent, 'must be present')
 })
 
 QUnit.test("Don't validate when value hasn't changed", function (assert) {
-  var form = $('form#new_user')
-  var input = form.find('input#user_name')
-  var label = $('label[for="user_name"]')
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_name')
+  var label = form.querySelector('label[for="user_name"]')
 
-  input.trigger('focusout')
-  assert.ok(input.parent().hasClass('field_with_errors'))
-  assert.ok(label.parent().hasClass('field_with_errors'))
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.ok(input.parentElement.classList.contains('field_with_errors'))
+  assert.ok(label.parentElement.classList.contains('field_with_errors'))
 
-  input.val('123')
-  input.trigger('focusout')
-  assert.ok(input.parent().hasClass('field_with_errors'))
-  assert.ok(label.parent().hasClass('field_with_errors'))
+  input.value = '123'
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.ok(input.parentElement.classList.contains('field_with_errors'))
+  assert.ok(label.parentElement.classList.contains('field_with_errors'))
 
-  input.trigger('change')
-  input.trigger('focusout')
-  assert.notOk(input.parent().hasClass('field_with_errors'))
-  assert.notOk(label.parent().hasClass('field_with_errors'))
+  input.dispatchEvent(new Event('change', { bubbles: true }))
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.notOk(input.parentElement.classList.contains('field_with_errors'))
+  assert.notOk(label.parentElement.classList.contains('field_with_errors'))
 })
 
 QUnit.test('Validate when error message needs to change', function (assert) {
-  var form = $('form#new_user')
-  var input = form.find('input#user_name')
-  var label = $('label[for="user_name"]')
+  var input = document.getElementById('user_name')
 
-  input.trigger('focusout')
-  assert.equal(input.parent().find('label.message').text(), 'must be present')
-  input.val('abc')
-  input.trigger('change')
-  input.trigger('focusout')
-  assert.equal(input.parent().find('label.message').text(), 'is invalid')
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.equal(input.parentElement.querySelector('label.message').textContent, 'must be present')
+  input.value = 'abc'
+  input.dispatchEvent(new Event('change', { bubbles: true }))
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.equal(input.parentElement.querySelector('label.message').textContent, 'is invalid')
 })
 
 QUnit.test("Don't validate confirmation when not a validatable input", function (assert) {
+  var fixture = document.getElementById('qunit-fixture')
+  var form = document.createElement('form')
+  var labelPassword = document.createElement('label')
+  var inputPassword = document.createElement('input')
+  var labelPasswordConfirmation = document.createElement('label')
+  var inputPasswordConfirmation = document.createElement('input')
+
   dataCsv = {
     html_settings: {
       type: 'ActionView::Helpers::FormBuilder',
       input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
       label_tag: '<div class="field_with_errors"><label id="label_tag"></label></div>'
     },
-    validators: { }
+    validators: {}
   }
 
-  $('#qunit-fixture')
-    .html('')
-    .append($('<form>', {
-      action: '/users',
-      'data-client-side-validations': JSON.stringify(dataCsv),
-      method: 'post',
-      id: 'new_user_2'
-    }))
-    .find('form')
-    .append($('<label for="user_2_password">Password</label>'))
-    .append($('<input />', {
-      name: 'user_2[password]',
-      id: 'user_2_password',
-      type: 'password'
-    }))
-    .append($('<label for="user_2_password_confirmation">Password Confirmation</label>'))
-    .append($('<input />', {
-      name: 'user_2[password_confirmation]',
-      id: 'user_2_password_confirmation',
-      type: 'password'
-    }))
+  fixture.replaceChildren()
 
-  $('form#new_user_2').validate()
-  var form = $('form#new_user_2')
-  var input = form.find('input#user_2_password_confirmation')
+  form.action = '/users'
+  form.dataset.clientSideValidations = JSON.stringify(dataCsv)
+  form.method = 'post'
+  form.id = 'new_user_2'
 
-  input.val('123')
-  input.trigger('focusout')
-  assert.notOk(input.parent().hasClass('field_with_errors'))
+  labelPassword.htmlFor = 'user_2_password'
+  labelPassword.textContent = 'Password'
+  form.appendChild(labelPassword)
+
+  inputPassword.name = 'user_2[password]'
+  inputPassword.id = 'user_2_password'
+  inputPassword.type = 'password'
+  form.appendChild(inputPassword)
+
+  labelPasswordConfirmation.htmlFor = 'user_2_password_confirmation'
+  labelPasswordConfirmation.textContent = 'Password Confirmation'
+  form.appendChild(labelPasswordConfirmation)
+
+  inputPasswordConfirmation.name = 'user_2[password_confirmation]'
+  inputPasswordConfirmation.id = 'user_2_password_confirmation'
+  inputPasswordConfirmation.type = 'password'
+  form.appendChild(inputPasswordConfirmation)
+
+  fixture.appendChild(form)
+
+  ClientSideValidations.validate(form)
+
+  inputPasswordConfirmation.value = '123'
+  inputPasswordConfirmation.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.notOk(inputPasswordConfirmation.parentElement.classList.contains('field_with_errors'))
 })
 
 QUnit.test("Don't validate disabled inputs", function (assert) {
+  var fixture = document.getElementById('qunit-fixture')
+  var form = document.createElement('form')
+  var label = document.createElement('label')
+  var input = document.createElement('input')
+
   dataCsv = {
     html_settings: {
       type: 'ActionView::Helpers::FormBuilder',
@@ -367,33 +455,38 @@ QUnit.test("Don't validate disabled inputs", function (assert) {
     validators: { 'user_2[name]': { presence: [{ message: 'must be present' }] } }
   }
 
-  $('#qunit-fixture')
-    .html('')
-    .append($('<form>', {
-      action: '/users',
-      'data-client-side-validations': JSON.stringify(dataCsv),
-      method: 'post',
-      id: 'new_user_2'
-    }))
-    .find('form')
-    .append($('<label for="user_2_name">name</label>'))
-    .append($('<input />', {
-      name: 'user_2[name]',
-      id: 'user_2_name',
-      type: 'text',
-      disabled: 'disabled'
-    }))
+  fixture.replaceChildren()
 
-  $('form#new_user_2').validate()
-  var form = $('form#new_user_2')
-  var input = form.find('input#user_2_name')
+  form.action = '/users'
+  form.dataset.clientSideValidations = JSON.stringify(dataCsv)
+  form.method = 'post'
+  form.id = 'new_user_2'
 
-  input.val('')
-  input.trigger('focusout')
-  assert.notOk(input.parent().hasClass('field_with_errors'))
+  label.htmlFor = 'user_2_name'
+  label.textContent = 'name'
+  form.appendChild(label)
+
+  input.name = 'user_2[name]'
+  input.id = 'user_2_name'
+  input.type = 'text'
+  input.disabled = true
+  form.appendChild(input)
+
+  fixture.appendChild(form)
+
+  ClientSideValidations.validate(form)
+
+  input.value = ''
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.notOk(input.parentElement.classList.contains('field_with_errors'))
 })
 
 QUnit.test("Don't validate dynamically disabled inputs", function (assert) {
+  var fixture = document.getElementById('qunit-fixture')
+  var form = document.createElement('form')
+  var label = document.createElement('label')
+  var input = document.createElement('input')
+
   dataCsv = {
     html_settings: {
       type: 'ActionView::Helpers::FormBuilder',
@@ -403,33 +496,39 @@ QUnit.test("Don't validate dynamically disabled inputs", function (assert) {
     validators: { 'user_2[name]': { presence: [{ message: 'must be present' }] } }
   }
 
-  $('#qunit-fixture')
-    .html('')
-    .append($('<form>', {
-      action: '/users',
-      'data-client-side-validations': JSON.stringify(dataCsv),
-      method: 'post',
-      id: 'new_user_2'
-    }))
-    .find('form')
-    .append($('<label for="user_2_name">name</label>'))
-    .append($('<input />', {
-      name: 'user_2[name]',
-      id: 'user_2_name',
-      type: 'text'
-    }))
-  $('form#new_user_2').validate()
-  var form = $('form#new_user_2')
-  var input = form.find('input#user_2_name')
+  fixture.replaceChildren()
 
-  input.attr('disabled', 'disabled')
-  input.val('')
-  input.trigger('focusout')
+  form.action = '/users'
+  form.dataset.clientSideValidations = JSON.stringify(dataCsv)
+  form.method = 'post'
+  form.id = 'new_user_2'
 
-  assert.notOk(input.parent().hasClass('field_with_errors'))
+  label.htmlFor = 'user_2_name'
+  label.textContent = 'name'
+  form.appendChild(label)
+
+  input.name = 'user_2[name]'
+  input.id = 'user_2_name'
+  input.type = 'text'
+  form.appendChild(input)
+
+  fixture.appendChild(form)
+
+  ClientSideValidations.validate(form)
+
+  input.disabled = true
+  input.value = ''
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+
+  assert.notOk(input.parentElement.classList.contains('field_with_errors'))
 })
 
 QUnit.test("Remove error messages when input tag has more than two css classes", function (assert) {
+  var fixture = document.getElementById('qunit-fixture')
+  var form = document.createElement('form')
+  var label = document.createElement('label')
+  var input = document.createElement('input')
+
   dataCsv = {
     html_settings: {
       type: 'ActionView::Helpers::FormBuilder',
@@ -439,75 +538,81 @@ QUnit.test("Remove error messages when input tag has more than two css classes",
     validators: { 'user_2[name]': { presence: [{ message: 'must be present' }] } }
   }
 
-  $('#qunit-fixture')
-    .html('')
-    .append($('<form>', {
-      action: '/users',
-      'data-client-side-validations': JSON.stringify(dataCsv),
-      method: 'post',
-      id: 'new_user_2'
-    }))
-    .find('form')
-    .append($('<label for="user_2_name">name</label>'))
-    .append($('<input />', {
-      name: 'user_2[name]',
-      id: 'user_2_name',
-      type: 'text'
-    }))
-  $('form#new_user_2').validate()
-  var form = $('form#new_user_2')
-  var input = form.find('input#user_2_name')
+  fixture.replaceChildren()
 
-  input.val('')
-  input.trigger('focusout')
+  form.action = '/users'
+  form.dataset.clientSideValidations = JSON.stringify(dataCsv)
+  form.method = 'post'
+  form.id = 'new_user_2'
 
-  assert.ok(input.parent().hasClass('field_with_errors'))
+  label.htmlFor = 'user_2_name'
+  label.textContent = 'name'
+  form.appendChild(label)
 
-  input.val('123')
-  input.trigger('change')
-  input.trigger('focusout')
+  input.name = 'user_2[name]'
+  input.id = 'user_2_name'
+  input.type = 'text'
+  form.appendChild(input)
 
-  assert.notOk(input.parent().hasClass('field_with_errors'))
-  assert.notOk(form.find('.field_with_errors').length)
+  fixture.appendChild(form)
+
+  ClientSideValidations.validate(form)
+
+  input.value = ''
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+
+  assert.ok(input.parentElement.classList.contains('field_with_errors'))
+
+  input.value = '123'
+  input.dispatchEvent(new Event('change', { bubbles: true }))
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+
+  assert.notOk(input.parentElement.classList.contains('field_with_errors'))
+  assert.equal(form.querySelectorAll('.field_with_errors').length, 0)
 })
 
 QUnit.test('ensure label is scoped to form', function (assert) {
-  var form = $('form#new_user')
-  var input = form.find('input#user_name')
-  var label = $('label[for="user_name"]')
+  var fixture = document.getElementById('qunit-fixture')
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_name')
+  var otherForm = document.createElement('form')
+  var otherLabel = document.createElement('label')
 
-  $('#qunit-fixture')
-    .prepend($('<form>', { id: 'other_form', 'data-client-side-validations': {}.to_json })
-      .append($('<label for="user_name">Name</label>')))
+  otherForm.id = 'other_form'
+  otherForm.dataset.clientSideValidations = '{}'
 
-  var otherLabel = $('form#other_form').find('label')
+  otherLabel.htmlFor = 'user_name'
+  otherLabel.textContent = 'Name'
+  otherForm.appendChild(otherLabel)
 
-  input.trigger('focusout')
-  assert.notOk(otherLabel.parent().hasClass('field_with_errors'))
+  fixture.prepend(otherForm)
+
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.notOk(otherLabel.parentElement.classList.contains('field_with_errors'))
 })
 
 QUnit.test('Return validation result', function (assert) {
-  var input = $('#user_name')
+  var input = document.getElementById('user_name')
 
-  assert.notOk(input.isValid(dataCsv.validators))
+  assert.notOk(ClientSideValidations.isValid(input, dataCsv.validators))
 
-  input.val('123')
-  input[0].dataset.csvChanged = 'true'
-  assert.ok(input.isValid(dataCsv.validators))
+  input.value = '123'
+  input.dataset.csvChanged = 'true'
+  assert.ok(ClientSideValidations.isValid(input, dataCsv.validators))
 })
 
 QUnit.test('Validate when focusouting and field has disabled validations', function (assert) {
-  var form = $('form#new_user')
-  var input = form.find('input#user_name')
-  var label = $('label[for="user_name"]')
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_name')
+  var label = form.querySelector('label[for="user_name"]')
 
-  input.disableClientSideValidations()
-  input.trigger('focusout')
-  assert.notOk(input.parent().hasClass('field_with_errors'))
-  assert.notOk(label.parent().hasClass('field_with_errors'))
+  ClientSideValidations.disable(input)
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.notOk(input.parentElement.classList.contains('field_with_errors'))
+  assert.notOk(label.parentElement.classList.contains('field_with_errors'))
 
-  input.enableClientSideValidations()
-  input.trigger('focusout')
-  assert.ok(input.parent().hasClass('field_with_errors'))
-  assert.ok(label.parent().hasClass('field_with_errors'))
+  ClientSideValidations.enable(input)
+  input.dispatchEvent(new Event('focusout', { bubbles: true }))
+  assert.ok(input.parentElement.classList.contains('field_with_errors'))
+  assert.ok(label.parentElement.classList.contains('field_with_errors'))
 })

--- a/test/javascript/public/test/validators/absence.js
+++ b/test/javascript/public/test/validators/absence.js
@@ -1,49 +1,60 @@
 QUnit.module('Absence options')
 
 QUnit.test('when value is not empty', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation' }
-  element.val('not empty')
+  element.value = 'not empty'
   assert.equal(ClientSideValidations.validators.local.absence(element, options), 'failed validation')
 })
 
 QUnit.test('when value is only spaces', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation' }
-  element.val('   ')
+  element.value = '   '
   assert.equal(ClientSideValidations.validators.local.absence(element, options), undefined)
 })
 
 QUnit.test('when value is empty', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation' }
   assert.equal(ClientSideValidations.validators.local.absence(element, options), undefined)
 })
 
 QUnit.test('when value is null from non-selected multi-select element', function (assert) {
-  var element = $('<select multiple="multiple">')
+  var element = document.createElement('select')
+  element.multiple = true
   var options = { message: 'failed validation' }
   assert.equal(ClientSideValidations.validators.local.absence(element, options), undefined)
 })
 
 QUnit.test('when value is not null from multi-select element', function (assert) {
-  var element = $('<select multiple="multiple">')
+  var element = document.createElement('select')
+  var option = document.createElement('option')
+  element.multiple = true
   var options = { message: 'failed validation' }
-  element.append('<option value="selected-option">Option</option>')
-  element.val('selected-option')
+  option.value = 'selected-option'
+  option.textContent = 'Option'
+  element.appendChild(option)
+  element.value = 'selected-option'
   assert.equal(ClientSideValidations.validators.local.absence(element, options), 'failed validation')
 })
 
 QUnit.test('when value is null from select element', function (assert) {
-  var element = $('<select>')
+  var element = document.createElement('select')
   var options = { message: 'failed validation' }
   assert.equal(ClientSideValidations.validators.local.absence(element, options), undefined)
 })
 
 QUnit.test('when value is not null from select element', function (assert) {
-  var element = $('<select>')
+  var element = document.createElement('select')
+  var option = document.createElement('option')
   var options = { message: 'failed validation' }
-  element.append('<option value="selected-option">Option</option>')
-  element.val('selected-option')
+  option.value = 'selected-option'
+  option.textContent = 'Option'
+  element.appendChild(option)
+  element.value = 'selected-option'
   assert.equal(ClientSideValidations.validators.local.absence(element, options), 'failed validation')
 })

--- a/test/javascript/public/test/validators/acceptance.js
+++ b/test/javascript/public/test/validators/acceptance.js
@@ -1,55 +1,63 @@
 QUnit.module('Acceptance options')
 
 QUnit.test('when checkbox and checked', function (assert) {
-  var element = $('<input type="checkbox" />')
+  var element = document.createElement('input')
+  element.type = 'checkbox'
   var options = { message: 'failed validation' }
-  element.prop('checked', true)
+  element.checked = true
   assert.equal(ClientSideValidations.validators.local.acceptance(element, options), undefined)
 })
 
 QUnit.test('when checkbox and not checked', function (assert) {
-  var element = $('<input type="checkbox" />')
+  var element = document.createElement('input')
+  element.type = 'checkbox'
   var options = { message: 'failed validation' }
   assert.equal(ClientSideValidations.validators.local.acceptance(element, options), 'failed validation')
 })
 
 QUnit.test('when text and value default of 1', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation' }
-  element.val('1')
+  element.value = '1'
   assert.equal(ClientSideValidations.validators.local.acceptance(element, options), undefined)
 })
 
 QUnit.test('when text and value \'1 and accept value is \'1\'', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation', accept: '1' }
-  element.val('1')
+  element.value = '1'
   assert.equal(ClientSideValidations.validators.local.acceptance(element, options), undefined)
 })
 
 QUnit.test('when text and value empty', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation' }
   assert.equal(ClientSideValidations.validators.local.acceptance(element, options), 'failed validation')
 })
 
 QUnit.test('when text and value \'1\' and accept value is 1', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation', accept: 1 }
-  element.val('1')
+  element.value = '1'
   assert.equal(ClientSideValidations.validators.local.acceptance(element, options), 'failed validation')
 })
 
 QUnit.test('when text and value \'yes\' and accept value is [\'yes\', \'y\']', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation', accept: ['yes', 'y'] }
-  element.val('yes')
+  element.value = 'yes'
   assert.equal(ClientSideValidations.validators.local.acceptance(element, options), undefined)
 })
 
 QUnit.test('when text and value \'true\' and accept value is [\'yes\', true]', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation', accept: ['yes', true] }
-  element.val('true')
+  element.value = 'true'
   assert.equal(ClientSideValidations.validators.local.acceptance(element, options), 'failed validation')
 })

--- a/test/javascript/public/test/validators/confirmation.js
+++ b/test/javascript/public/test/validators/confirmation.js
@@ -1,45 +1,62 @@
 QUnit.module('Confirmation options', {
   beforeEach: function () {
-    $('#qunit-fixture')
-      .append('<input id="password" type="password" autocomplete="new-password" />')
-      .append('<input id="password_confirmation" type="password" />')
-      .append('<input id="username" type="text" />')
-      .append('<input id="username_confirmation" type="text" />')
+    var fixture = document.getElementById('qunit-fixture')
+    var password = document.createElement('input')
+    var passwordConfirmation = document.createElement('input')
+    var username = document.createElement('input')
+    var usernameConfirmation = document.createElement('input')
+
+    password.id = 'password'
+    password.type = 'password'
+    password.autocomplete = 'new-password'
+    fixture.appendChild(password)
+
+    passwordConfirmation.id = 'password_confirmation'
+    passwordConfirmation.type = 'password'
+    fixture.appendChild(passwordConfirmation)
+
+    username.id = 'username'
+    username.type = 'text'
+    fixture.appendChild(username)
+
+    usernameConfirmation.id = 'username_confirmation'
+    usernameConfirmation.type = 'text'
+    fixture.appendChild(usernameConfirmation)
   }
 })
 
 QUnit.test('when values match (case sensitive)', function (assert) {
-  var passwordElement = $('#password')
-  var passwordConfirmationElement = $('#password_confirmation')
+  var passwordElement = document.getElementById('password')
+  var passwordConfirmationElement = document.getElementById('password_confirmation')
   var options = { message: 'failed validation' }
-  passwordElement.val('test')
-  passwordConfirmationElement.val('test')
+  passwordElement.value = 'test'
+  passwordConfirmationElement.value = 'test'
   assert.equal(ClientSideValidations.validators.local.confirmation(passwordElement, options), undefined)
 })
 
 QUnit.test('when values do not match', function (assert) {
-  var passwordElement = $('#password')
-  var passwordConfirmationElement = $('#password_confirmation')
+  var passwordElement = document.getElementById('password')
+  var passwordConfirmationElement = document.getElementById('password_confirmation')
   var options = { message: 'failed validation' }
-  passwordElement.val('test')
-  passwordConfirmationElement.val('bad test')
+  passwordElement.value = 'test'
+  passwordConfirmationElement.value = 'bad test'
   assert.equal(ClientSideValidations.validators.local.confirmation(passwordElement, options), 'failed validation')
 })
 
 QUnit.test('when values match (case insensitive)', function (assert) {
-  var usernameElement = $('#username')
-  var usernameConfirmationElement = $('#username_confirmation')
+  var usernameElement = document.getElementById('username')
+  var usernameConfirmationElement = document.getElementById('username_confirmation')
   var options = { message: 'failed validation' }
-  usernameElement.val('tEsT')
-  usernameConfirmationElement.val('test')
+  usernameElement.value = 'tEsT'
+  usernameConfirmationElement.value = 'test'
   assert.equal(ClientSideValidations.validators.local.confirmation(usernameElement, options), undefined)
 })
 
 QUnit.test('when values contain special characters', function (assert) {
-  var usernameElement = $('#username')
-  var usernameConfirmationElement = $('#username_confirmation')
+  var usernameElement = document.getElementById('username')
+  var usernameConfirmationElement = document.getElementById('username_confirmation')
   var options = { message: 'failed validation' }
-  usernameElement.val('te+st')
-  usernameConfirmationElement.val('te+st')
+  usernameElement.value = 'te+st'
+  usernameConfirmationElement.value = 'te+st'
   assert.equal(ClientSideValidations.validators.local.confirmation(usernameElement, options), undefined)
 })

--- a/test/javascript/public/test/validators/exclusion.js
+++ b/test/javascript/public/test/validators/exclusion.js
@@ -1,41 +1,47 @@
 QUnit.module('Exclusion options')
 
 QUnit.test('when value is not in the list', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation', 'in': [1, 2, 3] }
-  element.val('4')
+  element.value = '4'
   assert.equal(ClientSideValidations.validators.local.exclusion(element, options), undefined)
 })
 
 QUnit.test('when value is not in the range', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation', range: [1, 3] }
-  element.val('4')
+  element.value = '4'
   assert.equal(ClientSideValidations.validators.local.exclusion(element, options), undefined)
 })
 
 QUnit.test('when value is in the list', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation', 'in': [1, 2, 3] }
-  element.val('1')
+  element.value = '1'
   assert.equal(ClientSideValidations.validators.local.exclusion(element, options), 'failed validation')
 })
 
 QUnit.test('when value is in the range', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation', range: [1, 3] }
-  element.val('1')
+  element.value = '1'
   assert.equal(ClientSideValidations.validators.local.exclusion(element, options), 'failed validation')
 })
 
 QUnit.test('when allowing blank', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation', 'in': [1, 2, 3], allow_blank: true }
   assert.equal(ClientSideValidations.validators.local.exclusion(element, options), undefined)
 })
 
 QUnit.test('when not allowing blank', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation', 'in': [1, 2, 3] }
   assert.equal(ClientSideValidations.validators.local.exclusion(element, options), 'failed validation')
 })

--- a/test/javascript/public/test/validators/format.js
+++ b/test/javascript/public/test/validators/format.js
@@ -1,39 +1,47 @@
 QUnit.module('Format options')
 
 QUnit.test('when matching format', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation', 'with': /\d+/ }
-  element.val('123')
+  element.value = '123'
   assert.equal(ClientSideValidations.validators.local.format(element, options), undefined)
 })
 
 QUnit.test('when not matching format', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation', 'with': /\d+/ }
-  element.val('abc')
+  element.value = 'abc'
   assert.equal(ClientSideValidations.validators.local.format(element, options), 'failed validation')
 })
 
 QUnit.test('when allowing blank', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation', 'with': /\d+/, allow_blank: true }
   assert.equal(ClientSideValidations.validators.local.format(element, options), undefined)
 })
 
 QUnit.test('when not allowing blank', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation', 'with': /\d+/ }
   assert.equal(ClientSideValidations.validators.local.format(element, options), 'failed validation')
 })
 
 QUnit.test('when using the without option and the Regex is matched', function (assert) {
-  var element = $('<input type="text" value="Rock"/>')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation', without: /R/ }
+  element.value = 'Rock'
   assert.equal(ClientSideValidations.validators.local.format(element, options), 'failed validation')
 })
 
 QUnit.test('when using the without option and the Regex is not matched', function (assert) {
-  var element = $('<input type="text" value="Lock"/>')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation', without: /R/ }
+  element.value = 'Lock'
   assert.equal(ClientSideValidations.validators.local.format(element, options), undefined)
 })

--- a/test/javascript/public/test/validators/inclusion.js
+++ b/test/javascript/public/test/validators/inclusion.js
@@ -1,41 +1,47 @@
 QUnit.module('Inclusion options')
 
 QUnit.test('when value is in the list', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation', 'in': [1, 2, 3] }
-  element.val('1')
+  element.value = '1'
   assert.equal(ClientSideValidations.validators.local.inclusion(element, options), undefined)
 })
 
 QUnit.test('when value is in the range', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation', range: [1, 3] }
-  element.val('1')
+  element.value = '1'
   assert.equal(ClientSideValidations.validators.local.inclusion(element, options), undefined)
 })
 
 QUnit.test('when value is not in the list', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation', 'in': [1, 2, 3] }
-  element.val('4')
+  element.value = '4'
   assert.equal(ClientSideValidations.validators.local.inclusion(element, options), 'failed validation')
 })
 
 QUnit.test('when value is not in the range', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation', range: [1, 3] }
-  element.val('4')
+  element.value = '4'
   assert.equal(ClientSideValidations.validators.local.inclusion(element, options), 'failed validation')
 })
 
 QUnit.test('when allowing blank', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation', 'in': [1, 2, 3], allow_blank: true }
   assert.equal(ClientSideValidations.validators.local.inclusion(element, options), undefined)
 })
 
 QUnit.test('when not allowing blank', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation', 'in': [1, 2, 3] }
   assert.equal(ClientSideValidations.validators.local.inclusion(element, options), 'failed validation')
 })

--- a/test/javascript/public/test/validators/length.js
+++ b/test/javascript/public/test/validators/length.js
@@ -1,68 +1,78 @@
 QUnit.module('Length options')
 
 QUnit.test('when allowed length is 3 and value length is 3', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { messages: { is: 'failed validation' }, is: 3 }
-  element.val('123')
+  element.value = '123'
   assert.equal(ClientSideValidations.validators.local.length(element, options), undefined)
 })
 
 QUnit.test('when allowed length is 3 and value length is 4', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { messages: { is: 'failed validation' }, is: 3 }
-  element.val('1234')
+  element.value = '1234'
   assert.equal(ClientSideValidations.validators.local.length(element, options), 'failed validation')
 })
 
 QUnit.test('when allowed length is 3 and value length is 2', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { messages: { is: 'failed validation' }, is: 3 }
-  element.val('12')
+  element.value = '12'
   assert.equal(ClientSideValidations.validators.local.length(element, options), 'failed validation')
 })
 
 QUnit.test('when allowing blank and allowed length is 3', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { messages: { is: 'failed validation' }, is: 3, allow_blank: true }
   assert.equal(ClientSideValidations.validators.local.length(element, options), undefined)
 })
 
 QUnit.test('when allowing blank and minimum length is 3 and maximum length is 100', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { messages: { minimum: 'failed minimum validation', maximum: 'failed maximum validation' }, minimum: 3, maximum: 100, allow_blank: true }
   assert.equal(ClientSideValidations.validators.local.length(element, options), undefined)
 })
 
 QUnit.test('when not allowing blank and allowed length is 3', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { messages: { is: 'failed validation' }, is: 3 }
   assert.equal(ClientSideValidations.validators.local.length(element, options), 'failed validation')
 })
 
 QUnit.test('when allowed length minimum is 3 and value length is 3', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { messages: { is: 'failed validation' }, is: 3 }
-  element.val('123')
+  element.value = '123'
   assert.equal(ClientSideValidations.validators.local.length(element, options), undefined)
 })
 
 QUnit.test('when allowed length minimum is 3 and value length is 2', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { messages: { minimum: 'failed validation' }, minimum: 3 }
-  element.val('12')
+  element.value = '12'
   assert.equal(ClientSideValidations.validators.local.length(element, options), 'failed validation')
 })
 
 QUnit.test('when allowed length maximum is 3 and value length is 3', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { messages: { is: 'failed validation' }, is: 3 }
-  element.val('123')
+  element.value = '123'
   assert.equal(ClientSideValidations.validators.local.length(element, options), undefined)
 })
 
 QUnit.test('when allowed length maximum is 3 and value length is 4', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { messages: { maximum: 'failed validation' }, maximum: 3 }
-  element.val('1234')
+  element.value = '1234'
   assert.equal(ClientSideValidations.validators.local.length(element, options), 'failed validation')
 })

--- a/test/javascript/public/test/validators/numericality.js
+++ b/test/javascript/public/test/validators/numericality.js
@@ -1,284 +1,303 @@
 QUnit.module('Numericality options', {
   beforeEach: function () {
-    dataCsv = {
-      number_format: { separator: '.', delimiter: ',' }
+    var fixture = document.getElementById('qunit-fixture')
+    var form = document.createElement('form')
+    var input = document.createElement('input')
+
+    form.id = 'form'
+    form.ClientSideValidations = {
+      settings: {
+        number_format: { separator: '.', delimiter: ',' }
+      }
     }
 
-    $('#qunit-fixture')
-      .append($('<form>', {
-        action: '/users',
-        id: 'form',
-        method: 'post',
-        'data-client-side-validations': JSON.stringify(dataCsv)
-      }))
-      .find('form')
-      .append($('<input />', {
-        type: 'text'
-      }))
+    input.id = 'number_value'
+    input.type = 'text'
 
-    $('#qunit-fixture form').validate()
+    form.appendChild(input)
+    fixture.appendChild(form)
   },
 
   afterEach: function () {
-    $('#qunit-fixture').remove('form')
+    var form = document.getElementById('form')
+
+    if (form) {
+      form.remove()
+    }
   }
 })
 
 QUnit.test('when value is a number', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { numericality: 'failed validation' } }
-  element.val('123')
+  element.value = '123'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), undefined)
 })
 
 QUnit.test('when value is a decimal number', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { numericality: 'failed validation' } }
-  element.val('123.456')
+  element.value = '123.456'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), undefined)
 })
 
 QUnit.test('when there is a custom number format', function (assert) {
-  var element = $('#form input')
-  $('#qunit-fixture form')[0].ClientSideValidations.settings.number_format = { separator: ',', delimiter: '.' }
+  var element = document.getElementById('number_value')
+  document.getElementById('form').ClientSideValidations.settings.number_format = { separator: ',', delimiter: '.' }
   var options = { messages: { numericality: 'failed validation' } }
-  element.val('123,45')
+  element.value = '123,45'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), undefined)
 })
 
 QUnit.test('when value is not a number', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { numericality: 'failed validation' } }
-  element.val('abc123')
+  element.value = 'abc123'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), 'failed validation')
 })
 
 QUnit.test('when no value', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { numericality: 'failed validation' } }
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), 'failed validation')
 })
 
 QUnit.test('when no value and allowing blank', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { numericality: 'failed validation' }, allow_blank: true }
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), undefined)
 })
 
 QUnit.test('when bad value and allowing blank', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { numericality: 'failed validation' }, allow_blank: true }
-  element.val('abc123')
+  element.value = 'abc123'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), 'failed validation')
 })
 
 QUnit.test('when only allowing integers and allowing blank', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { only_integer: 'failed validation', numericality: 'failed validation' }, only_integer: true, allow_blank: true }
-  element.val('')
+  element.value = ''
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), undefined)
 })
 
 QUnit.test('when only allowing integers and value is integer', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { only_integer: 'failed validation', numericality: 'failed validation' }, only_integer: true }
-  element.val('123')
+  element.value = '123'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), undefined)
 })
 
 QUnit.test('when only allowing integers and value is integer with whitespace', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { only_integer: 'failed validation', numericality: 'failed validation' }, only_integer: true }
-  element.val(' 123 ')
+  element.value = ' 123 '
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), undefined)
 })
 
 QUnit.test('when only allowing integers and value has a negative or positive sign', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { only_integer: 'failed validation', numericality: 'failed validation' }, only_integer: true }
-  element.val('-23')
+  element.value = '-23'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), undefined)
-  element.val('+23')
+  element.value = '+23'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), undefined)
 })
 
 QUnit.test('when only allowing integers and value is not integer', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { only_integer: 'failed validation', numericality: 'failed validation' }, only_integer: true }
-  element.val('123.456')
+  element.value = '123.456'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), 'failed validation')
 })
 
 QUnit.test('when only allowing integers and value has a delimiter', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { only_integer: 'failed validation', numericality: 'failed validation' }, only_integer: true }
-  element.val('10,000')
+  element.value = '10,000'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), 'failed validation')
 })
 
 QUnit.test('when only allowing values greater than 10 and value is greater than 10', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { greater_than: 'failed validation', numericality: 'failed validation' }, greater_than: 10 }
-  element.val('11')
+  element.value = '11'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), undefined)
 })
 
 QUnit.test('when only allowing values greater than 10 and value is 10', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { greater_than: 'failed validation', numericality: 'failed validation' }, greater_than: 10 }
-  element.val('10')
+  element.value = '10'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), 'failed validation')
 })
 
 QUnit.test('when only allowing values greater than or equal to 10 and value is 10', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { greater_than_or_equal_to: 'failed validation', numericality: 'failed validation' }, greater_than_or_equal_to: 10 }
-  element.val('10')
+  element.value = '10'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), undefined)
 })
 
 QUnit.test('when only allowing values greater than or equal to 10 and value is 9', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { greater_than_or_equal_to: 'failed validation', numericality: 'failed validation' }, greater_than_or_equal_to: 10 }
-  element.val('9')
+  element.value = '9'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), 'failed validation')
 })
 
 QUnit.test('when only allowing values less than 10 and value is less than 10', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { less_than: 'failed validation', numericality: 'failed validation' }, less_than: 10 }
-  element.val('9')
+  element.value = '9'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), undefined)
 })
 
 QUnit.test('when only allowing values less than 10 and value is 10', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { less_than: 'failed validation', numericality: 'failed validation' }, less_than: 10 }
-  element.val('10')
+  element.value = '10'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), 'failed validation')
 })
 
 QUnit.test('when only allowing values less than or equal to 10 and value is 10', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { less_than_or_equal_to: 'failed validation', numericality: 'failed validation' }, less_than_or_equal_to: 10 }
-  element.val('10')
+  element.value = '10'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), undefined)
 })
 
 QUnit.test('when only allowing values less than or equal to 10 and value is 11', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { less_than_or_equal_to: 'failed validation', numericality: 'failed validation' }, less_than_or_equal_to: 10 }
-  element.val('11')
+  element.value = '11'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), 'failed validation')
 })
 
 QUnit.test('when only allowing values equal to 10 and value is 10', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { equal_to: 'failed validation', numericality: 'failed validation' }, equal_to: 10 }
-  element.val('10')
+  element.value = '10'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), undefined)
 })
 
 QUnit.test('when only allowing values equal to 10 and value is 11', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { equal_to: 'failed validation', numericality: 'failed validation' }, equal_to: 10 }
-  element.val('11')
+  element.value = '11'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), 'failed validation')
 })
 
 QUnit.test('when only allowing value equal to 0 and value is 1', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { equal_to: 'failed validation', numericality: 'failed validation' }, equal_to: 0 }
-  element.val('1')
+  element.value = '1'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), 'failed validation')
 })
 
 QUnit.test('when only allowing odd values and the value is odd', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { odd: 'failed validation', numericality: 'failed validation' }, odd: true }
-  element.val('11')
+  element.value = '11'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), undefined)
 })
 
 QUnit.test('when only allowing odd values and the value is even', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { odd: 'failed validation', numericality: 'failed validation' }, odd: true }
-  element.val('10')
+  element.value = '10'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), 'failed validation')
 })
 
 QUnit.test('when only allowing even values and the value is even', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { even: 'failed validation', numericality: 'failed validation' }, even: true }
-  element.val('10')
+  element.value = '10'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), undefined)
 })
 
 QUnit.test('when only allowing even values and the value is odd', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { even: 'failed validation', numericality: 'failed validation' }, even: true }
-  element.val('11')
+  element.value = '11'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), 'failed validation')
 })
 
 QUnit.test('when only allowing values other than 10 and value is 11', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { other_than: 'failed validation', numericality: 'failed validation' }, other_than: 10 }
-  element.val('11')
+  element.value = '11'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), undefined)
 })
 
 QUnit.test('when only allowing values other than 10 and value is 10', function (assert) {
-  var element = $('#form input')
+  var element = document.getElementById('number_value')
   var options = { messages: { other_than: 'failed validation', numericality: 'failed validation' }, other_than: 10 }
-  element.val('10')
+  element.value = '10'
   assert.equal(ClientSideValidations.validators.local.numericality(element, options), 'failed validation')
 })
 
 QUnit.test('when value refers to another present input', function (assert) {
-  var form = $('#form')
-  var element1 = $('<input type="text" name="points_1" />')
-  var element2 = $('<input type="text" name="points_2" />')
+  var form = document.getElementById('form')
+  var element1 = document.createElement('input')
+  var element2 = document.createElement('input')
   var options = { messages: { greater_than: 'failed to be greater', numericality: 'failed validation' }, greater_than: 'points_2' }
 
-  form.append(element1).append(element2)
-  $('#qunit-fixture')
-    .append(form)
+  element1.type = 'text'
+  element1.name = 'points_1'
+  form.appendChild(element1)
 
-  element1.val(0)
-  element2.val(1)
+  element2.type = 'text'
+  element2.name = 'points_2'
+  form.appendChild(element2)
+
+  element1.value = 0
+  element2.value = 1
   assert.equal(ClientSideValidations.validators.local.numericality(element1, options), 'failed to be greater')
-  element1.val(2)
+  element1.value = 2
   assert.equal(ClientSideValidations.validators.local.numericality(element1, options), undefined)
 })
 
 QUnit.test('when value refers to another present empty input', function (assert) {
-  var form = $('#form')
-  var element1 = $('<input type="text" name="points_1" />')
-  var element2 = $('<input type="text" name="points_2" />')
+  var form = document.getElementById('form')
+  var element1 = document.createElement('input')
+  var element2 = document.createElement('input')
   var options = { messages: { greater_than: 'failed to be greater', numericality: 'failed validation' }, greater_than: 'points_2' }
 
-  form.append(element1).append(element2)
-  $('#qunit-fixture')
-    .append(form)
+  element1.type = 'text'
+  element1.name = 'points_1'
+  form.appendChild(element1)
 
-  element1.val(0)
+  element2.type = 'text'
+  element2.name = 'points_2'
+  form.appendChild(element2)
+
+  element1.value = 0
   assert.equal(ClientSideValidations.validators.local.numericality(element1, options), undefined)
 })
 
 QUnit.test('when value refers to another present input but with more than one match', function (assert) {
-  var form = $('#form')
-  var element1 = $('<input type="text" name="points_1" />')
-  var element2 = $('<input type="text" name="points_2" />')
-  var element3 = $('<input type="text" name="points_21" />')
+  var form = document.getElementById('form')
+  var element1 = document.createElement('input')
+  var element2 = document.createElement('input')
+  var element3 = document.createElement('input')
   var options = { messages: { greater_than: 'failed to be greater', numericality: 'failed validation' }, greater_than: 'points_2' }
 
-  form.append(element1).append(element2).append(element3)
-  $('#qunit-fixture')
-    .append(form)
+  element1.type = 'text'
+  element1.name = 'points_1'
+  form.appendChild(element1)
 
-  element1.val(1)
-  element2.val(2)
-  element3.val(0)
+  element2.type = 'text'
+  element2.name = 'points_2'
+  form.appendChild(element2)
+
+  element3.type = 'text'
+  element3.name = 'points_21'
+  form.appendChild(element3)
+
+  element1.value = 1
+  element2.value = 2
+  element3.value = 0
   assert.equal(ClientSideValidations.validators.local.numericality(element1, options), undefined)
 })

--- a/test/javascript/public/test/validators/presence.js
+++ b/test/javascript/public/test/validators/presence.js
@@ -1,20 +1,23 @@
 QUnit.module('Presence options')
 
 QUnit.test('when value is not empty', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation' }
-  element.val('not empty')
+  element.value = 'not empty'
   assert.equal(ClientSideValidations.validators.local.presence(element, options), undefined)
 })
 
 QUnit.test('when value is empty', function (assert) {
-  var element = $('<input type="text" />')
+  var element = document.createElement('input')
+  element.type = 'text'
   var options = { message: 'failed validation' }
   assert.equal(ClientSideValidations.validators.local.presence(element, options), 'failed validation')
 })
 
 QUnit.test('when value is null from non-selected multi-select element', function (assert) {
-  var element = $('<select multiple="multiple">')
+  var element = document.createElement('select')
+  element.multiple = true
   var options = { message: 'failed validation' }
   assert.equal(ClientSideValidations.validators.local.presence(element, options), 'failed validation')
 })

--- a/test/javascript/public/test/validators/uniqueness.js
+++ b/test/javascript/public/test/validators/uniqueness.js
@@ -1,112 +1,89 @@
 QUnit.module('Uniqueness options', {
   beforeEach: function () {
     ClientSideValidations.remote_validators_prefix = undefined
-    dataCsv = {
-      html_settings: {
-        type: 'ActionView::Helpers::FormBuilder',
-        input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label class="message"></label></div>',
-        label_tag: '<div class="field_with_errors"><label id="label_tag"></label></div>'
-      },
-      validators: { 'user[email]': { uniqueness: [{ message: 'must be unique', scope: { name: 'pass' } }] }, presence: [{ message: 'must be present' }] }
-    }
-
-    $('#qunit-fixture')
-      .append($('<form>', {
-        action: '/users',
-        'data-client-side-validations': JSON.stringify(dataCsv),
-        method: 'post',
-        id: 'new_user'
-      }))
-      .find('form')
-      .append($('<input />', {
-        name: 'user[name]',
-        id: 'user_name',
-        type: 'text'
-      }))
-      .append($('<input />', {
-        name: 'user[email]',
-        id: 'user_email',
-        type: 'text'
-      }))
-
-    $('form#new_user').validate()
   }
 })
 
 QUnit.test('when matching local case-insensitive uniqueness for nested has-many resources', function (assert) {
-  dataCsv = {
-    html_settings: {
-      type: 'ActionView::Helpers::FormBuilder',
-      input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
-      label_tag: '<div class="field_with_errors"><label id="label_tag"></label></div>'
-    },
-    validators: { 'user[email]': { uniqueness: [{ message: 'must be unique' }] } }
-  }
-
-  $('#qunit-fixture')
-    .append($('<form>', {
-      action: '/users',
-      'data-client-side-validations': JSON.stringify(dataCsv),
-      method: 'post',
-      id: 'new_user_2'
-    }))
-    .find('form')
-    .append($('<input />', {
-      name: 'profile[user_attributes][0][email]',
-      id: 'user_0_email'
-    }))
-    .append($('<input />', {
-      name: 'profile[user_attributes][1][email]',
-      id: 'user_1_email'
-    }))
-
-  $('form#new_user_2').validate()
-
-  var user0EmailElement = $('#user_0_email')
-  var user1EmailElement = $('#user_1_email')
+  var fixture = document.getElementById('qunit-fixture')
+  var form = document.createElement('form')
+  var user0EmailElement = document.createElement('input')
+  var user1EmailElement = document.createElement('input')
   var options = { message: 'must be unique' }
 
-  user0EmailElement.val('not-locally-unique')
-  user1EmailElement.val('Not-Locally-Unique')
+  form.id = 'new_user_2'
+
+  user0EmailElement.id = 'user_0_email'
+  user0EmailElement.name = 'profile[user_attributes][0][email]'
+  form.appendChild(user0EmailElement)
+
+  user1EmailElement.id = 'user_1_email'
+  user1EmailElement.name = 'profile[user_attributes][1][email]'
+  form.appendChild(user1EmailElement)
+
+  fixture.appendChild(form)
+
+  user0EmailElement.value = 'not-locally-unique'
+  user1EmailElement.value = 'Not-Locally-Unique'
 
   assert.equal(ClientSideValidations.validators.local.uniqueness(user1EmailElement, options), 'must be unique')
 })
 
 QUnit.test('when matching case-sensitive local uniqueness for nested has-many resources', function (assert) {
-  dataCsv = {
-    html_settings: {
-      type: 'ActionView::Helpers::FormBuilder',
-      input_tag: '<div class="field_with_errors"><span id="input_tag"></span><label for="user_name" class="message"></label></div>',
-      label_tag: '<div class="field_with_errors"><label id="label_tag"></label></div>'
-    },
-    validators: { 'user[email]': { uniqueness: [{ message: 'must be unique' }] } }
-  }
-
-  $('#qunit-fixture')
-    .append($('<form>', {
-      action: '/users',
-      'data-client-side-validations': JSON.stringify(dataCsv),
-      method: 'post',
-      id: 'new_user_3'
-    }))
-    .find('form')
-    .append($('<input />', {
-      name: 'profile[user_attributes][0][email]',
-      id: 'user_0_email'
-    }))
-    .append($('<input />', {
-      name: 'profile[user_attributes][1][email]',
-      id: 'user_1_email'
-    }))
-
-  $('form#new_user_3').validate()
-
-  var user0EmailElement = $('#user_0_email')
-  var user1EmailElement = $('#user_1_email')
+  var fixture = document.getElementById('qunit-fixture')
+  var form = document.createElement('form')
+  var user0EmailElement = document.createElement('input')
+  var user1EmailElement = document.createElement('input')
   var options = { message: 'must be unique', case_sensitive: true }
 
-  user0EmailElement.val('locally-unique')
-  user1EmailElement.val('Locally-Unique')
+  form.id = 'new_user_3'
+
+  user0EmailElement.id = 'user_0_email'
+  user0EmailElement.name = 'profile[user_attributes][0][email]'
+  form.appendChild(user0EmailElement)
+
+  user1EmailElement.id = 'user_1_email'
+  user1EmailElement.name = 'profile[user_attributes][1][email]'
+  form.appendChild(user1EmailElement)
+
+  fixture.appendChild(form)
+
+  user0EmailElement.value = 'locally-unique'
+  user1EmailElement.value = 'Locally-Unique'
 
   assert.equal(ClientSideValidations.validators.local.uniqueness(user1EmailElement, options), undefined)
+})
+
+QUnit.test('when local uniqueness is restored, sibling fields are re-marked with csv dataset keys', function (assert) {
+  var fixture = document.getElementById('qunit-fixture')
+  var form = document.createElement('form')
+  var user0EmailElement = document.createElement('input')
+  var user1EmailElement = document.createElement('input')
+  var options = { message: 'must be unique' }
+
+  form.id = 'new_user_4'
+
+  user0EmailElement.id = 'user_0_email'
+  user0EmailElement.name = 'profile[user_attributes][0][email]'
+  form.appendChild(user0EmailElement)
+
+  user1EmailElement.id = 'user_1_email'
+  user1EmailElement.name = 'profile[user_attributes][1][email]'
+  form.appendChild(user1EmailElement)
+
+  fixture.appendChild(form)
+
+  user0EmailElement.value = 'not-locally-unique'
+  user1EmailElement.value = 'Not-Locally-Unique'
+
+  assert.equal(ClientSideValidations.validators.local.uniqueness(user1EmailElement, options), 'must be unique')
+  assert.strictEqual(user0EmailElement.dataset.csvNotLocallyUnique, 'true')
+  assert.strictEqual(user0EmailElement.dataset.notLocallyUnique, undefined)
+
+  user1EmailElement.value = 'now-unique'
+
+  assert.equal(ClientSideValidations.validators.local.uniqueness(user1EmailElement, options), undefined)
+  assert.strictEqual(user0EmailElement.dataset.csvNotLocallyUnique, undefined)
+  assert.strictEqual(user0EmailElement.dataset.csvChanged, 'true')
+  assert.strictEqual(user0EmailElement.dataset.changed, undefined)
 })

--- a/test/javascript/server.rb
+++ b/test/javascript/server.rb
@@ -27,16 +27,10 @@ class AssetPath < Rack::Static
 end
 
 use AssetPath, urls: ['/vendor/assets/javascripts'], root: File.expand_path('../..', settings.root)
-use AssetPath, urls: ['/vendor/assets/javascripts'], root: File.expand_path('../', $LOAD_PATH.find { |p| p.include?('jquery-rails') })
 
-DEFAULT_JQUERY_VERSION = '4.0.0'
-QUNIT_VERSION          = '2.25.0'
+QUNIT_VERSION = '2.25.0'
 
 helpers do
-  def jquery_version
-    params[:jquery] || DEFAULT_JQUERY_VERSION
-  end
-
   def qunit_version
     QUNIT_VERSION
   end
@@ -64,8 +58,9 @@ post '/users' do
   payload = data.to_json.gsub('<', '&lt;').gsub('>', '&gt;')
   <<-HTML
     <script>
-      if (window.top && window.top !== window)
-        window.top.jQuery.event.trigger('iframe:loaded', #{payload})
+      if (window.top && window.top !== window) {
+        window.top.dispatchEvent(new CustomEvent('iframe:loaded', { detail: #{payload} }))
+      }
     </script>
     <p id="response">Form submitted</p>
   HTML

--- a/test/javascript/views/index.erb
+++ b/test/javascript/views/index.erb
@@ -3,9 +3,8 @@
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>
 
-<%= script_tag "https://code.jquery.com/jquery-#{jquery_version}.min.js" %>
 <%= script_tag '/vendor/assets/javascripts/rails.validations.js' %>
-<%= script_tag "https://code.jquery.com/qunit/qunit-#{qunit_version}.js" %>
+<%= script_tag "https://cdn.jsdelivr.net/npm/qunit@#{qunit_version}/qunit/qunit.js" %>
 <%= script_tag 'settings' %>
 <%= script_tag 'validateElement' %>
 <%= test :validators, :form_builders, :callbacks %>

--- a/test/javascript/views/layout.erb
+++ b/test/javascript/views/layout.erb
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
     <title><%= @title %></title>
-    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-<%= qunit_version %>.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/qunit@<%= qunit_version %>/qunit/qunit.css">
   </head>
   <body>
     <%= yield %>

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -1,14 +1,50 @@
 /*!
- * Client Side Validations JS - v23.1.0 (https://github.com/DavyJonesLocker/client_side_validations)
+ * Client Side Validations JS - v24.0.0 (https://github.com/DavyJonesLocker/client_side_validations)
  * Copyright (c) 2026 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */
 
 (function (global, factory) {
-  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(require('jquery')) :
-  typeof define === 'function' && define.amd ? define(['jquery'], factory) :
-  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, global.ClientSideValidations = factory(global.jQuery));
-})(this, (function (jQuery) { 'use strict';
+  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+  typeof define === 'function' && define.amd ? define(factory) :
+  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, global.ClientSideValidations = factory());
+})(this, (function () { 'use strict';
+
+  const boundEventListeners = new WeakMap();
+  const addBoundEventListener = (element, eventName, listener) => {
+    element.addEventListener(eventName, listener);
+    const listeners = boundEventListeners.get(element) || [];
+    listeners.push({
+      eventName,
+      listener
+    });
+    boundEventListeners.set(element, listeners);
+  };
+  const bindElementEvents = (element, eventsToBind) => {
+    for (const eventName in eventsToBind) {
+      addBoundEventListener(element, eventName, eventsToBind[eventName]);
+    }
+  };
+  const clearBoundEventListeners = element => {
+    const listeners = boundEventListeners.get(element);
+    if (!listeners) {
+      return;
+    }
+    listeners.forEach(_ref => {
+      let {
+        eventName,
+        listener
+      } = _ref;
+      element.removeEventListener(eventName, listener);
+    });
+    boundEventListeners.delete(element);
+  };
+  const dispatchCustomEvent = (element, eventName, detail) => {
+    element.dispatchEvent(new CustomEvent(eventName, {
+      bubbles: true,
+      detail
+    }));
+  };
 
   const arrayHasValue = (value, otherValues) => {
     for (let i = 0, l = otherValues.length; i < l; i++) {
@@ -23,136 +59,190 @@
     element.innerHTML = html;
     return element.firstChild;
   };
+  const isDOMCollection = target => {
+    return Array.isArray(target) || typeof NodeList !== 'undefined' && target instanceof NodeList || typeof HTMLCollection !== 'undefined' && target instanceof HTMLCollection || typeof RadioNodeList !== 'undefined' && target instanceof RadioNodeList;
+  };
+  const isDOMElement = target => {
+    return target != null && target.nodeType === 1;
+  };
+  const getDOMElements = target => {
+    if (target == null) {
+      return [];
+    }
+    if (isDOMElement(target)) {
+      return [target];
+    }
+    if (isDOMCollection(target)) {
+      return Array.from(target).filter(isDOMElement);
+    }
+    return [];
+  };
+  const isFormElement = element => {
+    return element.tagName === 'FORM';
+  };
+  const isInputElement = element => {
+    switch (element.tagName) {
+      case 'INPUT':
+        return element.type !== 'submit' && element.type !== 'button';
+      case 'SELECT':
+      case 'TEXTAREA':
+        return true;
+      default:
+        return false;
+    }
+  };
+  const isVisible = element => {
+    return Boolean(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
+  };
   const isValuePresent = value => {
     return !/^\s*$/.test(value || '');
   };
 
+  const isNamedInputElement = element => {
+    return isInputElement(element) && element.name != null && element.name !== '';
+  };
+  const getFormControls = form => {
+    return Array.from(form.elements).filter(isInputElement);
+  };
+  const getFormInputs = form => {
+    return getFormControls(form).filter(element => {
+      return isNamedInputElement(element) && !element.disabled && isVisible(element);
+    });
+  };
+  const findFormElementByName = (form, name) => {
+    return getFormControls(form).find(element => element.name === name);
+  };
+  const enableForm = form => {
+    ClientSideValidations.enablers.form(form);
+  };
+  const enableForms = () => {
+    document.querySelectorAll(ClientSideValidations.selectors.forms).forEach(enableForm);
+  };
   const ClientSideValidations = {
     callbacks: {
       element: {
-        after: ($element, eventData) => {},
-        before: ($element, eventData) => {},
-        fail: ($element, message, addError, eventData) => addError(),
-        pass: ($element, removeError, eventData) => removeError()
+        after: (element, eventData) => {},
+        before: (element, eventData) => {},
+        fail: (element, message, addError, eventData) => addError(),
+        pass: (element, removeError, eventData) => removeError()
       },
       form: {
-        after: ($form, eventData) => {},
-        before: ($form, eventData) => {},
-        fail: ($form, eventData) => {},
-        pass: ($form, eventData) => {}
+        after: (form, eventData) => {},
+        before: (form, eventData) => {},
+        fail: (form, eventData) => {},
+        pass: (form, eventData) => {}
       }
     },
     eventsToBind: {
-      form: (form, $form) => ({
-        'submit.ClientSideValidations': eventData => {
-          if (!$form.isValid(form.ClientSideValidations.settings.validators)) {
+      form: form => ({
+        submit: eventData => {
+          if (!ClientSideValidations.isValid(form, form.ClientSideValidations.settings.validators)) {
             eventData.preventDefault();
             eventData.stopImmediatePropagation();
           }
         },
-        'ajax:beforeSend.ClientSideValidations': function (eventData) {
+        'ajax:beforeSend': function (eventData) {
           if (eventData.target === this) {
-            $form.isValid(form.ClientSideValidations.settings.validators);
+            ClientSideValidations.isValid(form, form.ClientSideValidations.settings.validators);
           }
         },
-        'form:validate:after.ClientSideValidations': eventData => {
-          ClientSideValidations.callbacks.form.after($form, eventData);
+        'form:validate:after': eventData => {
+          ClientSideValidations.callbacks.form.after(form, eventData);
         },
-        'form:validate:before.ClientSideValidations': eventData => {
-          ClientSideValidations.callbacks.form.before($form, eventData);
+        'form:validate:before': eventData => {
+          ClientSideValidations.callbacks.form.before(form, eventData);
         },
-        'form:validate:fail.ClientSideValidations': eventData => {
-          ClientSideValidations.callbacks.form.fail($form, eventData);
+        'form:validate:fail': eventData => {
+          ClientSideValidations.callbacks.form.fail(form, eventData);
         },
-        'form:validate:pass.ClientSideValidations': eventData => {
-          ClientSideValidations.callbacks.form.pass($form, eventData);
+        'form:validate:pass': eventData => {
+          ClientSideValidations.callbacks.form.pass(form, eventData);
         }
       }),
       input: form => ({
-        'focusout.ClientSideValidations': function () {
-          jQuery(this).isValid(form.ClientSideValidations.settings.validators);
+        focusout: function () {
+          ClientSideValidations.isValid(this, form.ClientSideValidations.settings.validators);
         },
-        'change.ClientSideValidations': function () {
+        change: function () {
           this.dataset.csvChanged = 'true';
         },
-        'element:validate:after.ClientSideValidations': function (eventData) {
-          ClientSideValidations.callbacks.element.after(jQuery(this), eventData);
+        'element:validate:after': function (eventData) {
+          ClientSideValidations.callbacks.element.after(this, eventData);
         },
-        'element:validate:before.ClientSideValidations': function (eventData) {
-          ClientSideValidations.callbacks.element.before(jQuery(this), eventData);
+        'element:validate:before': function (eventData) {
+          ClientSideValidations.callbacks.element.before(this, eventData);
         },
-        'element:validate:fail.ClientSideValidations': function (eventData, message) {
-          const $element = jQuery(this);
-          ClientSideValidations.callbacks.element.fail($element, message, function () {
-            form.ClientSideValidations.addError($element, message);
+        'element:validate:fail': function (eventData) {
+          const element = this;
+          const message = eventData.detail;
+          ClientSideValidations.callbacks.element.fail(element, message, function () {
+            form.ClientSideValidations.addError(element, message);
           }, eventData);
         },
-        'element:validate:pass.ClientSideValidations': function (eventData) {
-          const $element = jQuery(this);
-          ClientSideValidations.callbacks.element.pass($element, function () {
-            form.ClientSideValidations.removeError($element);
+        'element:validate:pass': function (eventData) {
+          const element = this;
+          ClientSideValidations.callbacks.element.pass(element, function () {
+            form.ClientSideValidations.removeError(element);
           }, eventData);
         }
       }),
-      inputConfirmation: ($element, form) => ({
-        'focusout.ClientSideValidations': () => {
-          $element[0].dataset.csvChanged = 'true';
-          $element.isValid(form.ClientSideValidations.settings.validators);
+      inputConfirmation: (elementToConfirm, form) => ({
+        focusout: () => {
+          elementToConfirm.dataset.csvChanged = 'true';
+          ClientSideValidations.isValid(elementToConfirm, form.ClientSideValidations.settings.validators);
         },
-        'keyup.ClientSideValidations': () => {
-          $element[0].dataset.csvChanged = 'true';
-          $element.isValid(form.ClientSideValidations.settings.validators);
+        keyup: () => {
+          elementToConfirm.dataset.csvChanged = 'true';
+          ClientSideValidations.isValid(elementToConfirm, form.ClientSideValidations.settings.validators);
         }
       })
     },
     enablers: {
       form: form => {
-        const $form = jQuery(form);
+        clearBoundEventListeners(form);
+        getFormControls(form).forEach(clearBoundEventListeners);
         form.ClientSideValidations = {
           settings: JSON.parse(form.dataset.clientSideValidations),
-          addError: ($element, message) => ClientSideValidations.formBuilders[form.ClientSideValidations.settings.html_settings.type].add($element, form.ClientSideValidations.settings.html_settings, message),
-          removeError: $element => ClientSideValidations.formBuilders[form.ClientSideValidations.settings.html_settings.type].remove($element, form.ClientSideValidations.settings.html_settings)
+          addError: (element, message) => ClientSideValidations.formBuilders[form.ClientSideValidations.settings.html_settings.type].add(element, form.ClientSideValidations.settings.html_settings, message),
+          removeError: element => ClientSideValidations.formBuilders[form.ClientSideValidations.settings.html_settings.type].remove(element, form.ClientSideValidations.settings.html_settings)
         };
-        const eventsToBind = ClientSideValidations.eventsToBind.form(form, $form);
-        for (const eventName in eventsToBind) {
-          const eventFunction = eventsToBind[eventName];
-          $form.on(eventName, eventFunction);
-        }
-        $form.find(ClientSideValidations.selectors.inputs).each(function () {
-          ClientSideValidations.enablers.input(this);
+        bindElementEvents(form, ClientSideValidations.eventsToBind.form(form));
+        getFormInputs(form).forEach(element => {
+          ClientSideValidations.enablers.input(element);
         });
       },
       input: function (input) {
-        const $input = jQuery(input);
         const form = input.form;
-        const $form = jQuery(form);
-        const eventsToBind = ClientSideValidations.eventsToBind.input(form);
-        for (const eventName in eventsToBind) {
-          const eventFunction = eventsToBind[eventName];
-          $input.filter(':not(:radio):not([id$=_confirmation])').each(function () {
-            this.dataset.csvValidate = 'true';
-          }).on(eventName, eventFunction);
+        if (!form) {
+          return;
         }
-        $input.filter(':checkbox').on('change.ClientSideValidations', function () {
-          jQuery(this).isValid(form.ClientSideValidations.settings.validators);
-        });
-        $input.filter('[id$=_confirmation]').each(function () {
-          const $element = jQuery(this);
-          const $elementToConfirm = $form.find("#".concat(this.id.match(/(.+)_confirmation/)[1], ":input"));
-          if ($elementToConfirm.length) {
-            const eventsToBind = ClientSideValidations.eventsToBind.inputConfirmation($elementToConfirm, form);
-            for (const eventName in eventsToBind) {
-              const eventFunction = eventsToBind[eventName];
-              jQuery("#".concat($element.attr('id'))).on(eventName, eventFunction);
+        clearBoundEventListeners(input);
+        const eventsToBind = ClientSideValidations.eventsToBind.input(form);
+        if (input.type !== 'radio' && !(input.id && input.id.endsWith('_confirmation'))) {
+          input.dataset.csvValidate = 'true';
+          bindElementEvents(input, eventsToBind);
+        }
+        if (input.type === 'checkbox') {
+          bindElementEvents(input, {
+            change: function () {
+              ClientSideValidations.isValid(this, form.ClientSideValidations.settings.validators);
             }
+          });
+        }
+        if (input.id && input.id.endsWith('_confirmation')) {
+          const elementToConfirm = document.getElementById(input.id.match(/(.+)_confirmation/)[1]);
+          if (elementToConfirm && elementToConfirm.form === form) {
+            bindElementEvents(input, ClientSideValidations.eventsToBind.inputConfirmation(elementToConfirm, form));
           }
-        });
+        }
       }
     },
     formBuilders: {
       'ActionView::Helpers::FormBuilder': {
-        add: ($element, settings, message) => {
-          const element = $element[0];
+        add: (element, settings, message) => {
+          if (!element) {
+            return;
+          }
           const form = element.form;
           const inputErrorTemplate = createElementFromHTML(settings.input_tag);
           let inputErrorElement = element.closest(".".concat(inputErrorTemplate.getAttribute('class').replace(/ /g, '.')));
@@ -182,8 +272,10 @@
             labelMessageElement.textContent = message;
           }
         },
-        remove: ($element, settings) => {
-          const element = $element[0];
+        remove: (element, settings) => {
+          if (!element) {
+            return;
+          }
           const form = element.form;
           const inputErrorClass = createElementFromHTML(settings.input_tag).getAttribute('class');
           const inputErrorElement = element.closest(".".concat(inputErrorClass.replace(/ /g, '.')));
@@ -213,8 +305,8 @@
       }
     },
     selectors: {
-      inputs: ':input:not(button):not([type="submit"])[name]:visible:enabled',
-      validate_inputs: ':input:enabled:visible[data-csv-validate]',
+      inputs: 'input:not([type="submit"]):not([type="button"])[name], select[name], textarea[name]',
+      validate_inputs: 'input[data-csv-validate]:not([type="submit"]):not([type="button"]), select[data-csv-validate], textarea[data-csv-validate]',
       forms: 'form[data-client-side-validations]'
     },
     validators: {
@@ -228,23 +320,31 @@
       remote: {}
     },
     disable: target => {
-      const $target = jQuery(target);
-      $target.off('.ClientSideValidations');
-      if ($target.is('form')) {
-        ClientSideValidations.disable($target.find(':input'));
-      } else {
-        delete $target[0].dataset.csvValid;
-        delete $target[0].dataset.csvChanged;
-        $target.filter(':input').each(function () {
-          delete this.dataset.csvValidate;
-        });
-      }
+      getDOMElements(target).forEach(element => {
+        clearBoundEventListeners(element);
+        if (isFormElement(element)) {
+          getFormControls(element).forEach(input => {
+            clearBoundEventListeners(input);
+            delete input.dataset.csvValid;
+            delete input.dataset.csvChanged;
+            delete input.dataset.csvValidate;
+          });
+          return;
+        }
+        delete element.dataset.csvValid;
+        delete element.dataset.csvChanged;
+        if (isInputElement(element)) {
+          delete element.dataset.csvValidate;
+        }
+      });
     },
     reset: form => {
-      const $form = jQuery(form);
       ClientSideValidations.disable(form);
       for (const key in form.ClientSideValidations.settings.validators) {
-        form.ClientSideValidations.removeError($form.find("[name=\"".concat(key, "\"]")));
+        const element = findFormElementByName(form, key);
+        if (element) {
+          form.ClientSideValidations.removeError(element);
+        }
       }
       ClientSideValidations.enablers.form(form);
     },
@@ -258,21 +358,23 @@
     start: () => {
       const initializeOnEvent = ClientSideValidations.initializeOnEvent();
       if (initializeOnEvent != null) {
-        jQuery(document).on(initializeOnEvent, () => jQuery(ClientSideValidations.selectors.forms).validate());
+        document.addEventListener(initializeOnEvent, enableForms);
+      } else if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', enableForms, {
+          once: true
+        });
       } else {
-        jQuery(() => jQuery(ClientSideValidations.selectors.forms).validate());
+        enableForms();
       }
     }
   };
 
-  const absenceLocalValidator = ($element, options) => {
-    const element = $element[0];
+  const absenceLocalValidator = (element, options) => {
     if (isValuePresent(element.value)) {
       return options.message;
     }
   };
-  const presenceLocalValidator = ($element, options) => {
-    const element = $element[0];
+  const presenceLocalValidator = (element, options) => {
     if (!isValuePresent(element.value)) {
       return options.message;
     }
@@ -288,8 +390,7 @@
     }
     return value === acceptOption;
   };
-  const acceptanceLocalValidator = ($element, options) => {
-    const element = $element[0];
+  const acceptanceLocalValidator = (element, options) => {
     let valid = true;
     if (element.type === 'checkbox') {
       valid = element.checked;
@@ -308,8 +409,7 @@
   const hasValidFormat = (value, withOptions, withoutOptions) => {
     return withOptions && isMatching(value, withOptions) || withoutOptions && !isMatching(value, withoutOptions);
   };
-  const formatLocalValidator = ($element, options) => {
-    const element = $element[0];
+  const formatLocalValidator = (element, options) => {
     const value = element.value;
     if (options.allow_blank && !isValuePresent(value)) {
       return;
@@ -394,8 +494,7 @@
     }
     return runFunctionValidations(formattedValue, form, options);
   };
-  const numericalityLocalValidator = ($element, options) => {
-    const element = $element[0];
+  const numericalityLocalValidator = (element, options) => {
     const value = element.value;
     if (options.allow_blank && !isValuePresent(value)) {
       return;
@@ -425,8 +524,7 @@
       }
     }
   };
-  const lengthLocalValidator = ($element, options) => {
-    const element = $element[0];
+  const lengthLocalValidator = (element, options) => {
     const value = element.value;
     if (options.allow_blank && !isValuePresent(value)) {
       return;
@@ -450,23 +548,20 @@
     }
     return options.in && isInList(value, options.in) || options.range && isInRange(value, options.range);
   };
-  const exclusionLocalValidator = ($element, options) => {
-    const element = $element[0];
+  const exclusionLocalValidator = (element, options) => {
     const value = element.value;
     if (isIncluded(value, options, false) || !options.allow_blank && !isValuePresent(value)) {
       return options.message;
     }
   };
-  const inclusionLocalValidator = ($element, options) => {
-    const element = $element[0];
+  const inclusionLocalValidator = (element, options) => {
     const value = element.value;
     if (!isIncluded(value, options, true)) {
       return options.message;
     }
   };
 
-  const confirmationLocalValidator = ($element, options) => {
-    const element = $element[0];
+  const confirmationLocalValidator = (element, options) => {
     let value = element.value;
     let confirmationValue = document.getElementById("".concat(element.id, "_confirmation")).value;
     if (!options.case_sensitive) {
@@ -484,17 +579,16 @@
       otherValue = otherValue.toLowerCase();
     }
     if (otherValue === value) {
-      element.dataset.notLocallyUnique = true;
+      element.dataset.csvNotLocallyUnique = 'true';
       return false;
     }
-    if (element.dataset.notLocallyUnique) {
-      delete element.dataset.notLocallyUnique;
-      element.dataset.changed = true;
+    if (element.dataset.csvNotLocallyUnique) {
+      delete element.dataset.csvNotLocallyUnique;
+      element.dataset.csvChanged = 'true';
     }
     return true;
   };
-  const uniquenessLocalValidator = ($element, options) => {
-    const element = $element[0];
+  const uniquenessLocalValidator = (element, options) => {
     const elementName = element.name;
     const matches = elementName.match(/^(.+_attributes\])\[\d+\](.+)$/);
     if (!matches) {
@@ -529,42 +623,38 @@
     confirmation: confirmationLocalValidator,
     uniqueness: uniquenessLocalValidator
   };
-  jQuery.fn.disableClientSideValidations = function () {
-    ClientSideValidations.disable(this);
-    return this;
-  };
-  jQuery.fn.enableClientSideValidations = function () {
-    const selectors = {
-      forms: 'form',
-      inputs: 'input'
-    };
-    for (const selector in selectors) {
-      const enablers = selectors[selector];
-      this.filter(ClientSideValidations.selectors[selector]).each(function () {
-        ClientSideValidations.enablers[enablers](this);
-      });
-    }
-    return this;
-  };
-  jQuery.fn.resetClientSideValidations = function () {
-    this.filter(ClientSideValidations.selectors.forms).each(function () {
-      ClientSideValidations.reset(this);
+  ClientSideValidations.enable = target => {
+    getDOMElements(target).forEach(element => {
+      if (isFormElement(element)) {
+        ClientSideValidations.enablers.form(element);
+      } else if (isInputElement(element)) {
+        ClientSideValidations.enablers.input(element);
+      }
     });
-    return this;
+    return target;
   };
-  jQuery.fn.validate = function () {
-    this.filter(ClientSideValidations.selectors.forms).each(function () {
-      jQuery(this).enableClientSideValidations();
+  ClientSideValidations.validate = target => {
+    getDOMElements(target).forEach(element => {
+      if (isFormElement(element)) {
+        ClientSideValidations.enable(element);
+      }
     });
-    return this;
+    return target;
   };
-  jQuery.fn.isValid = function (validators) {
-    const obj = jQuery(this[0]);
-    if (obj.is('form')) {
-      return validateForm(obj, validators);
-    } else {
-      return validateElement(obj, validatorsFor(this[0].name, validators));
+  ClientSideValidations.isValid = (target, validators) => {
+    const element = getDOMElements(target)[0];
+    if (!element) {
+      return true;
     }
+    if (!validators) {
+      var _form$ClientSideValid;
+      const form = isFormElement(element) ? element : element.form;
+      validators = form === null || form === void 0 || (_form$ClientSideValid = form.ClientSideValidations) === null || _form$ClientSideValid === void 0 || (_form$ClientSideValid = _form$ClientSideValid.settings) === null || _form$ClientSideValid === void 0 ? void 0 : _form$ClientSideValid.validators;
+    }
+    if (isFormElement(element)) {
+      return validateForm(element, validators || {});
+    }
+    return validateElement(element, validatorsFor(element.name, validators || {}));
   };
   const cleanNestedElementName = (elementName, nestedMatches, validators) => {
     for (const validatorName in validators) {
@@ -583,97 +673,103 @@
     return elementName;
   };
   const validatorsFor = (elementName, validators) => {
+    if (!elementName || !validators) {
+      return {};
+    }
     if (Object.prototype.hasOwnProperty.call(validators, elementName)) {
       return validators[elementName];
     }
     return validators[cleanElementName(elementName, validators)] || {};
   };
-  const validateForm = ($form, validators) => {
+  const getValidationInputs = form => {
+    return Array.from(form.elements).filter(element => {
+      if (element.dataset.csvValidate == null || element.disabled) {
+        return false;
+      }
+      return isVisible(element);
+    });
+  };
+  const validateForm = (form, validators) => {
     let valid = true;
-    $form.trigger('form:validate:before.ClientSideValidations');
-    $form.find(ClientSideValidations.selectors.validate_inputs).each(function () {
-      if (!jQuery(this).isValid(validators)) {
+    dispatchCustomEvent(form, 'form:validate:before');
+    getValidationInputs(form).forEach(element => {
+      if (!validateElement(element, validatorsFor(element.name, validators))) {
         valid = false;
       }
-      return true;
     });
     if (valid) {
-      $form.trigger('form:validate:pass.ClientSideValidations');
+      dispatchCustomEvent(form, 'form:validate:pass');
     } else {
-      $form.trigger('form:validate:fail.ClientSideValidations');
+      dispatchCustomEvent(form, 'form:validate:fail');
     }
-    $form.trigger('form:validate:after.ClientSideValidations');
+    dispatchCustomEvent(form, 'form:validate:after');
     return valid;
   };
-  const passElement = $element => {
-    const element = $element[0];
-    $element.trigger('element:validate:pass.ClientSideValidations');
+  const passElement = element => {
+    dispatchCustomEvent(element, 'element:validate:pass');
     delete element.dataset.csvValid;
   };
-  const failElement = ($element, message) => {
-    const element = $element[0];
-    $element.trigger('element:validate:fail.ClientSideValidations', message);
+  const failElement = (element, message) => {
+    dispatchCustomEvent(element, 'element:validate:fail', message);
     element.dataset.csvValid = 'false';
   };
-  const afterValidate = $element => {
-    const element = $element[0];
-    $element.trigger('element:validate:after.ClientSideValidations');
+  const afterValidate = element => {
+    dispatchCustomEvent(element, 'element:validate:after');
     return element.dataset.csvValid !== 'false';
   };
-  const executeValidator = (validatorFunctions, validatorFunction, validatorOptions, $element) => {
+  const executeValidator = (validatorFunctions, validatorFunction, validatorOptions, element) => {
     for (const validatorOption in validatorOptions) {
       if (!validatorOptions[validatorOption]) {
         continue;
       }
-      const message = validatorFunction.call(validatorFunctions, $element, validatorOptions[validatorOption]);
+      const message = validatorFunction.call(validatorFunctions, element, validatorOptions[validatorOption]);
       if (message) {
-        failElement($element, message);
+        failElement(element, message);
         return false;
       }
     }
     return true;
   };
-  const executeValidators = (validatorFunctions, $element, validators) => {
+  const executeValidators = (validatorFunctions, element, validators) => {
     for (const validator in validators) {
       if (!validatorFunctions[validator]) {
         continue;
       }
-      if (!executeValidator(validatorFunctions, validatorFunctions[validator], validators[validator], $element)) {
+      if (!executeValidator(validatorFunctions, validatorFunctions[validator], validators[validator], element)) {
         return false;
       }
     }
     return true;
   };
-  const isMarkedForDestroy = $element => {
-    const element = $element[0];
+  const isMarkedForDestroy = element => {
     const elementName = element.name;
-    if (/\[([^\]]*?)\]$/.test(elementName)) {
+    const form = element.form;
+    if (form && /\[([^\]]*?)\]$/.test(elementName)) {
       const destroyInputName = elementName.replace(/\[([^\]]*?)\]$/, '[_destroy]');
-      const destroyInputElement = document.querySelector("input[name=\"".concat(destroyInputName, "\"]"));
+      const destroyInputElement = form.querySelector("input[name=\"".concat(destroyInputName, "\"]"));
       if (destroyInputElement && destroyInputElement.value === '1') {
         return true;
       }
     }
     return false;
   };
-  const executeAllValidators = ($element, validators) => {
-    const element = $element[0];
+  const executeAllValidators = (element, validators) => {
     if (element.dataset.csvChanged === 'false' || element.disabled) {
       return;
     }
     element.dataset.csvChanged = 'false';
-    if (executeValidators(ClientSideValidations.validators.all(), $element, validators)) {
-      passElement($element);
+    if (executeValidators(ClientSideValidations.validators.all(), element, validators)) {
+      passElement(element);
     }
   };
-  const validateElement = ($element, validators) => {
-    $element.trigger('element:validate:before.ClientSideValidations');
-    if (isMarkedForDestroy($element)) {
-      passElement($element);
+  const validateElement = (element, validators) => {
+    dispatchCustomEvent(element, 'element:validate:before');
+    if (isMarkedForDestroy(element)) {
+      passElement(element);
     } else {
-      executeAllValidators($element, validators);
+      executeAllValidators(element, validators);
     }
-    return afterValidate($element);
+    return afterValidate(element);
   };
   if (!window.ClientSideValidations) {
     window.ClientSideValidations = ClientSideValidations;


### PR DESCRIPTION
Drop the remaining jQuery dependency from the published JavaScript
runtime and move the validation flow to native DOM APIs.

ClientSideValidations.enable(), validate(), isValid(), disable(), and
reset() now work with DOM elements and DOM collections instead of
jQuery objects. Validation callbacks and local validators also receive
native nodes, which keeps custom integrations aligned with the new
runtime surface.

Replace jQuery event wiring with native CustomEvent dispatch and
addEventListener hooks. Update visibility checks, dataset state,
uniqueness handling, and helper utilities so the runtime can traverse
forms and inputs without jQuery while preserving the existing
validation behavior.

Refresh the QUnit suite to build fixtures with plain DOM methods and
assert against native events and callback arguments. Regenerate the
bundled assets, switch the test harness to a neutral QUnit CDN, and
remove jquery from the package metadata.

Document the 24.0.0 breaking changes in the README and changelog, and
bump the gem and npm package versions for the release.