### PR TITLE
Validate hidden inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 25.0.0 / unreleased
 
+* [FEATURE] Add `data-csv-validate-hidden` opt-in to validate inputs that are not visible in the DOM (e.g. native `<select>` elements wrapped by a custom-select JavaScript widget)
 * [BUGFIX] Remove unused `inputs` and `validate_inputs` entries from `ClientSideValidations.selectors`; only `forms` is read by the runtime, so overriding the others previously had no effect
 * [FEATURE] Breaking change: remove unused JavaScript source exports
   - Deep imports of `src/validators/local/*` must use named exports instead of the removed default object exports, for example `import { acceptanceLocalValidator } from '@client-side-validations/client-side-validations/src/validators/local/acceptance'`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 25.0.0 / unreleased
 
+* [BUGFIX] Remove unused `inputs` and `validate_inputs` entries from `ClientSideValidations.selectors`; only `forms` is read by the runtime, so overriding the others previously had no effect
 * [FEATURE] Breaking change: remove unused JavaScript source exports
   - Deep imports of `src/validators/local/*` must use named exports instead of the removed default object exports, for example `import { acceptanceLocalValidator } from '@client-side-validations/client-side-validations/src/validators/local/acceptance'`
   - Remove the unused `addClass` and `removeClass` exports from `src/utils.js`

--- a/README.md
+++ b/README.md
@@ -205,6 +205,22 @@ The syntax is the same as `form_for`:
 **Note:** ClientSideValidations requires `id` attributes on form fields to
 work, so it will force `form_with` to generate ids.
 
+### Validating hidden inputs ###
+
+By default ClientSideValidations skips inputs that are not visible in the
+DOM (no `offsetWidth`, `offsetHeight`, or client rects). If you wrap a
+native form control with a custom widget that hides the original element
+(for example a custom-select library that replaces `<select>` with its own
+UI), add `data-csv-validate-hidden` to the original element so it is still
+validated:
+
+```erb
+<%= f.select :country, options, {}, data: { csv_validate_hidden: true } %>
+```
+
+The attribute is presence-based; any value (including no value) opts in.
+Remove the attribute to fall back to the default visibility check.
+
 ## Validators order ##
 
 By default, ClientSideValidations will perform the validations in the same order

--- a/dist/client-side-validations.esm.js
+++ b/dist/client-side-validations.esm.js
@@ -297,8 +297,6 @@ const ClientSideValidations = {
     }
   },
   selectors: {
-    inputs: 'input:not([type="submit"]):not([type="button"])[name], select[name], textarea[name]',
-    validate_inputs: 'input[data-csv-validate]:not([type="submit"]):not([type="button"]), select[data-csv-validate], textarea[data-csv-validate]',
     forms: 'form[data-client-side-validations]'
   },
   validators: {

--- a/dist/client-side-validations.esm.js
+++ b/dist/client-side-validations.esm.js
@@ -86,6 +86,9 @@ const isInputElement = element => {
 const isVisible = element => {
   return Boolean(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
 };
+const isValidatable = element => {
+  return element.dataset.csvValidateHidden != null || isVisible(element);
+};
 const isValuePresent = value => {
   return !/^\s*$/.test(value || '');
 };
@@ -98,7 +101,7 @@ const getFormControls = form => {
 };
 const getFormInputs = form => {
   return getFormControls(form).filter(element => {
-    return isNamedInputElement(element) && !element.disabled && isVisible(element);
+    return isNamedInputElement(element) && !element.disabled && isValidatable(element);
   });
 };
 const findFormElementByName = (form, name) => {
@@ -676,7 +679,7 @@ const getValidationInputs = form => {
     if (element.dataset.csvValidate == null || element.disabled) {
       return false;
     }
-    return isVisible(element);
+    return isValidatable(element);
   });
 };
 const validateForm = (form, validators) => {

--- a/dist/client-side-validations.js
+++ b/dist/client-side-validations.js
@@ -303,8 +303,6 @@
       }
     },
     selectors: {
-      inputs: 'input:not([type="submit"]):not([type="button"])[name], select[name], textarea[name]',
-      validate_inputs: 'input[data-csv-validate]:not([type="submit"]):not([type="button"]), select[data-csv-validate], textarea[data-csv-validate]',
       forms: 'form[data-client-side-validations]'
     },
     validators: {

--- a/dist/client-side-validations.js
+++ b/dist/client-side-validations.js
@@ -92,6 +92,9 @@
   const isVisible = element => {
     return Boolean(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
   };
+  const isValidatable = element => {
+    return element.dataset.csvValidateHidden != null || isVisible(element);
+  };
   const isValuePresent = value => {
     return !/^\s*$/.test(value || '');
   };
@@ -104,7 +107,7 @@
   };
   const getFormInputs = form => {
     return getFormControls(form).filter(element => {
-      return isNamedInputElement(element) && !element.disabled && isVisible(element);
+      return isNamedInputElement(element) && !element.disabled && isValidatable(element);
     });
   };
   const findFormElementByName = (form, name) => {
@@ -682,7 +685,7 @@
       if (element.dataset.csvValidate == null || element.disabled) {
         return false;
       }
-      return isVisible(element);
+      return isValidatable(element);
     });
   };
   const validateForm = (form, validators) => {

--- a/src/core.js
+++ b/src/core.js
@@ -250,8 +250,6 @@ const ClientSideValidations = {
     }
   },
   selectors: {
-    inputs: 'input:not([type="submit"]):not([type="button"])[name], select[name], textarea[name]',
-    validate_inputs: 'input[data-csv-validate]:not([type="submit"]):not([type="button"]), select[data-csv-validate], textarea[data-csv-validate]',
     forms: 'form[data-client-side-validations]'
   },
   validators: {

--- a/src/core.js
+++ b/src/core.js
@@ -1,5 +1,6 @@
 import { bindElementEvents, clearBoundEventListeners } from './events'
-import { createElementFromHTML, getDOMElements, isFormElement, isInputElement, isVisible } from './utils'
+
+import { createElementFromHTML, getDOMElements, isFormElement, isInputElement, isValidatable } from './utils'
 
 const isNamedInputElement = (element) => {
   return isInputElement(element) && element.name != null && element.name !== ''
@@ -11,7 +12,7 @@ const getFormControls = (form) => {
 
 const getFormInputs = (form) => {
   return getFormControls(form).filter((element) => {
-    return isNamedInputElement(element) && !element.disabled && isVisible(element)
+    return isNamedInputElement(element) && !element.disabled && isValidatable(element)
   })
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import ClientSideValidations from './core'
 import { dispatchCustomEvent } from './events'
-import { getDOMElements, isFormElement, isInputElement, isVisible } from './utils'
+import { getDOMElements, isFormElement, isInputElement, isValidatable } from './utils'
 
 import { absenceLocalValidator, presenceLocalValidator } from './validators/local/absence_presence'
 import { acceptanceLocalValidator } from './validators/local/acceptance'
@@ -106,7 +106,7 @@ const getValidationInputs = (form) => {
       return false
     }
 
-    return isVisible(element)
+    return isValidatable(element)
   })
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -58,8 +58,12 @@ export const isInputElement = (element) => {
   }
 }
 
-export const isVisible = (element) => {
+const isVisible = (element) => {
   return Boolean(element.offsetWidth || element.offsetHeight || element.getClientRects().length)
+}
+
+export const isValidatable = (element) => {
+  return element.dataset.csvValidateHidden != null || isVisible(element)
 }
 
 export const isValuePresent = (value) => {

--- a/test/javascript/public/test/form_builders/validateForm.js
+++ b/test/javascript/public/test/form_builders/validateForm.js
@@ -182,6 +182,62 @@ QUnit.test('Inputs inside hidden containers do not stop form submission (async)'
   }, 250)
 })
 
+QUnit.test('Inputs hidden after enable with data-csv-validate-hidden are validated on submit (async)', function (assert) {
+  var done = assert.async()
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_name')
+  var label = form.querySelector('label[for="user_name"]')
+  var hiddenContainer = document.createElement('div')
+
+  input.dataset.csvValidateHidden = ''
+  hiddenContainer.hidden = true
+  form.insertBefore(hiddenContainer, input)
+  hiddenContainer.appendChild(input)
+  hiddenContainer.appendChild(label)
+
+  form.requestSubmit()
+
+  setTimeout(function () {
+    var iframe = document.querySelector('iframe')
+    var response = iframe && iframe.contentDocument && iframe.contentDocument.querySelector('#response')
+
+    assert.notOk(response)
+    assert.ok(input.parentElement.classList.contains('field_with_errors'))
+    done()
+  }, 250)
+})
+
+QUnit.test('Inputs hidden before enable with data-csv-validate-hidden are bound (async)', function (assert) {
+  var done = assert.async()
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_name')
+  var label = form.querySelector('label[for="user_name"]')
+  var hiddenContainer = document.createElement('div')
+
+  ClientSideValidations.disable(form)
+
+  input.dataset.csvValidateHidden = ''
+  hiddenContainer.hidden = true
+  form.insertBefore(hiddenContainer, input)
+  hiddenContainer.appendChild(input)
+  hiddenContainer.appendChild(label)
+
+  ClientSideValidations.validate(form)
+
+  assert.strictEqual(input.dataset.csvValidate, 'true')
+
+  form.requestSubmit()
+
+  setTimeout(function () {
+    var iframe = document.querySelector('iframe')
+    var response = iframe && iframe.contentDocument && iframe.contentDocument.querySelector('#response')
+
+    assert.notOk(response)
+    assert.ok(input.parentElement.classList.contains('field_with_errors'))
+    done()
+  }, 250)
+})
+
 QUnit.test('Decorative (without name) inputs aren\'t validated (async)', function (assert) {
   var done = assert.async()
   var form = document.getElementById('new_user')

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -303,8 +303,6 @@
       }
     },
     selectors: {
-      inputs: 'input:not([type="submit"]):not([type="button"])[name], select[name], textarea[name]',
-      validate_inputs: 'input[data-csv-validate]:not([type="submit"]):not([type="button"]), select[data-csv-validate], textarea[data-csv-validate]',
       forms: 'form[data-client-side-validations]'
     },
     validators: {

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -92,6 +92,9 @@
   const isVisible = element => {
     return Boolean(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
   };
+  const isValidatable = element => {
+    return element.dataset.csvValidateHidden != null || isVisible(element);
+  };
   const isValuePresent = value => {
     return !/^\s*$/.test(value || '');
   };
@@ -104,7 +107,7 @@
   };
   const getFormInputs = form => {
     return getFormControls(form).filter(element => {
-      return isNamedInputElement(element) && !element.disabled && isVisible(element);
+      return isNamedInputElement(element) && !element.disabled && isValidatable(element);
     });
   };
   const findFormElementByName = (form, name) => {
@@ -682,7 +685,7 @@
       if (element.dataset.csvValidate == null || element.disabled) {
         return false;
       }
-      return isVisible(element);
+      return isValidatable(element);
     });
   };
   const validateForm = (form, validators) => {


### PR DESCRIPTION
We use some custom selects which hide the original select. In v23 it was possible to add them back in `validate_inputs`. After the removal of jQuery in v24 `validate_inputs` is dead.

This would also be a clean way for this Issue: https://github.com/DavyJonesLocker/client_side_validations/issues/616


BTW: I couldnt run the tests but I hope they work :D