### PR TITLE
Remove unused JS source exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 25.0.0 / unreleased
+
+* [FEATURE] Breaking change: remove unused JavaScript source exports
+  - Deep imports of `src/validators/local/*` must use named exports instead of the removed default object exports, for example `import { acceptanceLocalValidator } from '@client-side-validations/client-side-validations/src/validators/local/acceptance'`
+  - Remove the unused `addClass` and `removeClass` exports from `src/utils.js`
+
 ## 24.0.0 / 2026-04-19
 * [FEATURE] Breaking change: Remove the jQuery runtime dependency and the old jQuery plugin aliases from the published JavaScript assets
 * [FEATURE] Breaking change: Public JavaScript APIs now work with native DOM elements and DOM collections instead of jQuery-wrapped objects

--- a/dist/client-side-validations.esm.js
+++ b/dist/client-side-validations.esm.js
@@ -1,5 +1,5 @@
 /*!
- * Client Side Validations JS - v24.0.0 (https://github.com/DavyJonesLocker/client_side_validations)
+ * Client Side Validations JS - v25.0.0 (https://github.com/DavyJonesLocker/client_side_validations)
  * Copyright (c) 2026 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */
@@ -25,10 +25,8 @@ const clearBoundEventListeners = element => {
     return;
   }
   listeners.forEach(_ref => {
-    let {
-      eventName,
-      listener
-    } = _ref;
+    let eventName = _ref.eventName,
+      listener = _ref.listener;
     element.removeEventListener(eventName, listener);
   });
   boundEventListeners.delete(element);

--- a/dist/client-side-validations.js
+++ b/dist/client-side-validations.js
@@ -1,5 +1,5 @@
 /*!
- * Client Side Validations JS - v24.0.0 (https://github.com/DavyJonesLocker/client_side_validations)
+ * Client Side Validations JS - v25.0.0 (https://github.com/DavyJonesLocker/client_side_validations)
  * Copyright (c) 2026 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */
@@ -31,10 +31,8 @@
       return;
     }
     listeners.forEach(_ref => {
-      let {
-        eventName,
-        listener
-      } = _ref;
+      let eventName = _ref.eventName,
+        listener = _ref.listener;
       element.removeEventListener(eventName, listener);
     });
     boundEventListeners.delete(element);

--- a/lib/client_side_validations/version.rb
+++ b/lib/client_side_validations/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ClientSideValidations
-  VERSION = '24.0.0'
+  VERSION = '25.0.0'
 end

--- a/package.json
+++ b/package.json
@@ -22,16 +22,16 @@
     "test": "test/javascript/run-qunit.mjs"
   },
   "devDependencies": {
-    "@babel/core": "^7.29.0",
-    "@babel/preset-env": "^7.29.2",
+    "@babel/core": "^7.29.7",
+    "@babel/preset-env": "^7.29.7",
     "@rollup/plugin-babel": "^7.0.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "chrome-launcher": "^1.2.1",
     "eslint": "^9.39.4",
-    "eslint-plugin-compat": "^7.0.1",
+    "eslint-plugin-compat": "^7.0.2",
     "neostandard": "^0.13.0",
-    "puppeteer-core": "^25.0.2",
-    "rollup": "^4.60.2",
+    "puppeteer-core": "^25.1.0",
+    "rollup": "^4.60.4",
     "rollup-plugin-copy": "^3.5.0"
   },
   "main": "dist/client-side-validations.js",
@@ -62,7 +62,7 @@
       "/vendor/"
     ]
   },
-  "version": "24.0.0",
+  "version": "25.0.0",
   "directories": {
     "lib": "lib",
     "test": "test"

--- a/src/events.js
+++ b/src/events.js
@@ -34,9 +34,3 @@ export const dispatchCustomEvent = (element, eventName, detail) => {
     detail
   }))
 }
-
-export default {
-  bindElementEvents,
-  clearBoundEventListeners,
-  dispatchCustomEvent
-}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,9 +1,3 @@
-export const addClass = (element, customClass) => {
-  if (customClass) {
-    element.classList.add(...customClass.split(' '))
-  }
-}
-
 export const arrayHasValue = (value, otherValues) => {
   for (let i = 0, l = otherValues.length; i < l; i++) {
     if (value === otherValues[i]) {
@@ -70,22 +64,4 @@ export const isVisible = (element) => {
 
 export const isValuePresent = (value) => {
   return !/^\s*$/.test(value || '')
-}
-
-export const removeClass = (element, customClass) => {
-  if (customClass) {
-    element.classList.remove(...customClass.split(' '))
-  }
-}
-
-export default {
-  addClass,
-  arrayHasValue,
-  createElementFromHTML,
-  getDOMElements,
-  isFormElement,
-  isInputElement,
-  isVisible,
-  isValuePresent,
-  removeClass
 }

--- a/src/validators/local/absence_presence.js
+++ b/src/validators/local/absence_presence.js
@@ -11,8 +11,3 @@ export const presenceLocalValidator = (element, options) => {
     return options.message
   }
 }
-
-export default {
-  absenceLocalValidator,
-  presenceLocalValidator
-}

--- a/src/validators/local/acceptance.js
+++ b/src/validators/local/acceptance.js
@@ -29,7 +29,3 @@ export const acceptanceLocalValidator = (element, options) => {
     return options.message
   }
 }
-
-export default {
-  acceptanceLocalValidator
-}

--- a/src/validators/local/confirmation.js
+++ b/src/validators/local/confirmation.js
@@ -11,7 +11,3 @@ export const confirmationLocalValidator = (element, options) => {
     return options.message
   }
 }
-
-export default {
-  confirmationLocalValidator
-}

--- a/src/validators/local/exclusion_inclusion.js
+++ b/src/validators/local/exclusion_inclusion.js
@@ -37,8 +37,3 @@ export const inclusionLocalValidator = (element, options) => {
     return options.message
   }
 }
-
-export default {
-  exclusionLocalValidator,
-  inclusionLocalValidator
-}

--- a/src/validators/local/format.js
+++ b/src/validators/local/format.js
@@ -19,7 +19,3 @@ export const formatLocalValidator = (element, options) => {
     return options.message
   }
 }
-
-export default {
-  formatLocalValidator
-}

--- a/src/validators/local/length.js
+++ b/src/validators/local/length.js
@@ -32,7 +32,3 @@ export const lengthLocalValidator = (element, options) => {
 
   return runValidations(value.length, options)
 }
-
-export default {
-  lengthLocalValidator
-}

--- a/src/validators/local/numericality.js
+++ b/src/validators/local/numericality.js
@@ -101,7 +101,3 @@ export const numericalityLocalValidator = (element, options) => {
 
   return runValidations(formattedValue, form, options)
 }
-
-export default {
-  numericalityLocalValidator
-}

--- a/src/validators/local/uniqueness.js
+++ b/src/validators/local/uniqueness.js
@@ -45,7 +45,3 @@ export const uniquenessLocalValidator = (element, options) => {
     return options.message
   }
 }
-
-export default {
-  uniquenessLocalValidator
-}

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -1,5 +1,5 @@
 /*!
- * Client Side Validations JS - v24.0.0 (https://github.com/DavyJonesLocker/client_side_validations)
+ * Client Side Validations JS - v25.0.0 (https://github.com/DavyJonesLocker/client_side_validations)
  * Copyright (c) 2026 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */
@@ -31,10 +31,8 @@
       return;
     }
     listeners.forEach(_ref => {
-      let {
-        eventName,
-        listener
-      } = _ref;
+      let eventName = _ref.eventName,
+        listener = _ref.listener;
       element.removeEventListener(eventName, listener);
     });
     boundEventListeners.delete(element);


### PR DESCRIPTION
Drop unused default exports from helpers and local validator modules, and remove the unused addClass/removeClass helpers after the jQuery removal.