### PR TITLE
Remove dead selector aliases

### DIFF
--- a/dist/client-side-validations.esm.js
+++ b/dist/client-side-validations.esm.js
@@ -297,8 +297,6 @@ const ClientSideValidations = {
     }
   },
   selectors: {
-    inputs: 'input:not([type="submit"]):not([type="button"])[name], select[name], textarea[name]',
-    validate_inputs: 'input[data-csv-validate]:not([type="submit"]):not([type="button"]), select[data-csv-validate], textarea[data-csv-validate]',
     forms: 'form[data-client-side-validations]'
   },
   validators: {

--- a/dist/client-side-validations.js
+++ b/dist/client-side-validations.js
@@ -303,8 +303,6 @@
       }
     },
     selectors: {
-      inputs: 'input:not([type="submit"]):not([type="button"])[name], select[name], textarea[name]',
-      validate_inputs: 'input[data-csv-validate]:not([type="submit"]):not([type="button"]), select[data-csv-validate], textarea[data-csv-validate]',
       forms: 'form[data-client-side-validations]'
     },
     validators: {

--- a/src/core.js
+++ b/src/core.js
@@ -250,8 +250,6 @@ const ClientSideValidations = {
     }
   },
   selectors: {
-    inputs: 'input:not([type="submit"]):not([type="button"])[name], select[name], textarea[name]',
-    validate_inputs: 'input[data-csv-validate]:not([type="submit"]):not([type="button"]), select[data-csv-validate], textarea[data-csv-validate]',
     forms: 'form[data-client-side-validations]'
   },
   validators: {

--- a/test/javascript/public/test/form_builders/validateForm.js
+++ b/test/javascript/public/test/form_builders/validateForm.js
@@ -204,6 +204,39 @@ QUnit.test('Decorative (without name) inputs aren\'t validated (async)', functio
   }, 250)
 })
 
+QUnit.test('Associated inputs outside the form are validated on submit (async)', function (assert) {
+  var done = assert.async()
+  var fixture = document.getElementById('qunit-fixture')
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_name')
+  var outsideInput = document.createElement('input')
+
+  input.value = 'Test'
+
+  outsideInput.name = 'user[name]'
+  outsideInput.id = 'user_name_external'
+  outsideInput.type = 'text'
+  outsideInput.setAttribute('form', form.id)
+  fixture.appendChild(outsideInput)
+
+  ClientSideValidations.validate(form)
+
+  assert.ok(outsideInput.dataset.csvValidate)
+
+  form.requestSubmit()
+
+  setTimeout(function () {
+    var iframe = document.querySelector('iframe')
+    var response = iframe && iframe.contentDocument && iframe.contentDocument.querySelector('#response')
+
+    assert.notOk(response)
+    assert.notOk(input.parentElement.classList.contains('field_with_errors'))
+    assert.ok(outsideInput.parentElement.classList.contains('field_with_errors'))
+    assert.ok(outsideInput.parentElement.querySelector('label.message'))
+    done()
+  }, 250)
+})
+
 QUnit.test('Resetting client side validations', function (assert) {
   var form = document.getElementById('new_user')
   var input = document.getElementById('user_name')

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -303,8 +303,6 @@
       }
     },
     selectors: {
-      inputs: 'input:not([type="submit"]):not([type="button"])[name], select[name], textarea[name]',
-      validate_inputs: 'input[data-csv-validate]:not([type="submit"]):not([type="button"]), select[data-csv-validate], textarea[data-csv-validate]',
       forms: 'form[data-client-side-validations]'
     },
     validators: {


### PR DESCRIPTION
Drop `selectors.inputs` and `selectors.validate_inputs` from the runtime surface. They stopped participating in validation when 1e22209 replaced jQuery traversal with `form.elements`, DOM helpers, and `dataset.csvValidate` checks, leaving `selectors.forms` as the only remaining selector used at runtime.

Keeping these dead fields around suggests selector-driven behavior is still supported when the 24.x API is intentionally DOM-first.

Reintroducing them would be a regression because it encourages users to couple to unsupported internals and points the runtime back toward the old descendant-query model that the jQuery removal intentionally removed.

It is now possible to validate form-associated input that lives outside the form subtree. That behavior is new with the `form.elements`-based implementation and was not possible before, because the old `jQuery.find(...)` path could only reach descendants of the form element.