### PR TITLE
Skip validation when csvValidate is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Deep imports of `src/validators/local/*` must use named exports instead of the removed default object exports, for example `import { acceptanceLocalValidator } from '@client-side-validations/client-side-validations/src/validators/local/acceptance'`
   - Remove the unused `addClass` and `removeClass` exports from `src/utils.js`
   - Explicitly remove dead \`inputs\` and \`validate_inputs\` entries from \`ClientSideValidations.selectors\`; only \`forms\` is read by the runtime`
+* [BUGFIX] Correctly skip validation for elements where `data-csv-validate` is explicitly set to `"false"`
 
 ## 24.0.0 / 2026-04-19
 * [FEATURE] Breaking change: Remove the jQuery runtime dependency and the old jQuery plugin aliases from the published JavaScript assets

--- a/dist/client-side-validations.esm.js
+++ b/dist/client-side-validations.esm.js
@@ -673,7 +673,7 @@ const validatorsFor = (elementName, validators) => {
 };
 const getValidationInputs = form => {
   return Array.from(form.elements).filter(element => {
-    if (element.dataset.csvValidate == null || element.disabled) {
+    if (element.dataset.csvValidate !== 'true' || element.disabled) {
       return false;
     }
     return isVisible(element);

--- a/dist/client-side-validations.js
+++ b/dist/client-side-validations.js
@@ -679,7 +679,7 @@
   };
   const getValidationInputs = form => {
     return Array.from(form.elements).filter(element => {
-      if (element.dataset.csvValidate == null || element.disabled) {
+      if (element.dataset.csvValidate !== 'true' || element.disabled) {
         return false;
       }
       return isVisible(element);

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ const validatorsFor = (elementName, validators) => {
 
 const getValidationInputs = (form) => {
   return Array.from(form.elements).filter((element) => {
-    if (element.dataset.csvValidate == null || element.disabled) {
+    if (element.dataset.csvValidate !== 'true' || element.disabled) {
       return false
     }
 

--- a/test/javascript/public/test/form_builders/validateForm.js
+++ b/test/javascript/public/test/form_builders/validateForm.js
@@ -272,6 +272,26 @@ QUnit.test('Disable client side validations on all child inputs', function (asse
   assert.notOk(input.parentElement.querySelector('label.message'))
 })
 
+QUnit.test('Validate form with an input with csvValidate set to false (async)', function (assert) {
+  var done = assert.async()
+  var form = document.getElementById('new_user')
+  var input = document.getElementById('user_name')
+
+  input.value = ''
+  input.dataset.csvValidate = 'false'
+
+  form.requestSubmit()
+
+  setTimeout(function () {
+    var iframe = document.querySelector('iframe')
+    var response = iframe && iframe.contentDocument && iframe.contentDocument.querySelector('#response')
+
+    assert.notOk(input.parentElement.classList.contains('field_with_errors'), 'Input should not have errors because validation was skipped')
+    assert.ok(response, 'Form should have been submitted successfully')
+    done()
+  }, 250)
+})
+
 QUnit.test('Disable ignores non-element nodes in mixed collections', function (assert) {
   var input = document.getElementById('user_name')
   var textNode = document.createTextNode('ignored node')

--- a/vendor/assets/javascripts/rails.validations.js
+++ b/vendor/assets/javascripts/rails.validations.js
@@ -679,7 +679,7 @@
   };
   const getValidationInputs = form => {
     return Array.from(form.elements).filter(element => {
-      if (element.dataset.csvValidate == null || element.disabled) {
+      if (element.dataset.csvValidate !== 'true' || element.disabled) {
         return false;
       }
       return isVisible(element);


### PR DESCRIPTION
Currently, the runtime only skips validation if the `data-csv-validate` attribute is missing. If it's explicitly set to `"false"`, the element is still included in the validation inputs because `"false" == null` is false.

Change the check to ensure that only elements with `csvValidate` set to `"true"` are validated. This allows users to dynamically disable validation for specific elements by setting the attribute to `"false"`.